### PR TITLE
added a way for resources to specify alternate hosts facilitating multip...

### DIFF
--- a/src/mapper.js
+++ b/src/mapper.js
@@ -50,12 +50,21 @@ Mapper.prototype = {
     }.bind(this), {name: resourceName, methods: {}});
   },
 
-  urlFor: function(path, urlParams) {
+  urlFor: function(path, urlParams, host) {
     // using `Utils.extend` avoids undesired changes to `urlParams`
     var params = Utils.extend({}, urlParams);
-    var normalizedPath = /^\//.test(path) ? path : '/' + path;
-    var host = this.host.replace(/\/$/, '');
+    var normalizedPath = path;
 
+    if (typeof host === "undefined" || host === null) {
+      host = this.host;
+    }
+
+    host = host.replace(/\/$/, '');
+
+    if (host !== '') {
+      normalizedPath = /^\//.test(path) ? path : '/' + path;
+    }
+    
     // does not includes the body param into the URL
     delete params[this.bodyAttr];
 
@@ -105,7 +114,7 @@ Mapper.prototype = {
 
       var body = (params || {})[this.bodyAttr];
       var gatewayOpts = Utils.extend({}, {
-        url: this.urlFor(descriptor.path, params),
+        url: this.urlFor(descriptor.path, params, descriptor.host),
         method: descriptor.method,
         processor: descriptor.processor || rules.processor,
         params: params,

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -58,6 +58,10 @@ Mapper.prototype = {
     if (typeof host === "undefined" || host === null) {
       host = this.host;
     }
+    
+    if (host === false) {
+      host = '';
+    }
 
     host = host.replace(/\/$/, '');
 

--- a/test/mapper-test.js
+++ b/test/mapper-test.js
@@ -335,6 +335,18 @@ describe('Mapper', function() {
         });
       });
 
+      describe('explicit empty host, specified by false, with "/"', function() {
+        it('returns host and path', function() {
+          expect(mapper.urlFor('/path', null, false)).to.equals('/path');
+        });
+      });
+
+      describe('explicit empty host, specified by false, without "/"', function() {
+        it('returns host and path', function() {
+          expect(mapper.urlFor('path', null, false)).to.equals('path');
+        });
+      });
+
       describe('explicit host with "/"', function() {
         it('returns host and path', function() {
           expect(mapper.urlFor('/path', null, 'http://alt-url')).to.equals('http://alt-url/path');


### PR DESCRIPTION
...le endpoints for a resource, as well as permitting specifying empty hosts to work with HATEOAS APIs where one may be given an absolute url.

I saw the `var normalizedPath = /^\//.test(path) ? path : '/' + path;` line was preventing one from defining a resource where the parameter is the *entire* url, which can happen in HATEOAS applications when a resource returns not an id but the whole URL, so I've made this change. 

I don't know if this is a *really* good idea. Perhaps a smaller change is warranted and when a alternate host is desired an alternate manifest should be defined. What do you think?

Example:

    var manifest = {
      host: 'http://localhost:8000/api/v2',
      resources: {
        Branch: {
          all: {path: '/branches/'},
          one: {path: '/branches/{id}/'},
          oneUrl: {path: '{url}', host: ''},
          old: {path: '/branches/{id}/', host: ''http://localhost:8000/api/v1/''},
        }
      }
    }
