### PR TITLE
made headers from options higher priority than built-in headers.

### DIFF
--- a/src/gateway/jquery-gateway.js
+++ b/src/gateway/jquery-gateway.js
@@ -40,7 +40,8 @@ var JQueryGateway = CreateGateway({
       requestMethod = 'POST';
       this.body = this.body || {};
       if (typeof this.body === 'object') this.body._method = method;
-      this.opts.headers = Utils.extend(this.opts.header, {'X-HTTP-Method-Override': method});
+      this.opts.headers = Utils.extend({'X-HTTP-Method-Override': method}, 
+        this.opts.headers);
     }
 
     var defaults = {type: requestMethod, data: Utils.params(this.body)};

--- a/src/gateway/node-vanilla-gateway.js
+++ b/src/gateway/node-vanilla-gateway.js
@@ -17,18 +17,18 @@ var NodeVanillaGateway = CreateGateway({
     if (emulateHTTP) {
       this.body = this.body || {};
       if (typeof this.body === 'object') this.body._method = method;
-      opts.headers = Utils.extend({}, opts.headers, {
+      opts.headers = Utils.extend({}, {
         'X-HTTP-Method-Override': method
-      });
+      }, opts.headers);
     }
 
     var body = this.body ? Utils.params(this.body) : '';
 
     if (canIncludeBody) {
-      opts.headers = Utils.extend({}, opts.headers, {
+      opts.headers = Utils.extend({}, {
         'Content-Type': 'application/x-www-form-urlencoded',
         'Content-Length': body.length
-      });
+      }, opts.headers);
     }
 
     var request = http.request(opts, this.onResponse.bind(this));


### PR DESCRIPTION
Hello, I was trying to make a custom "batch requests" createGateway function like https://github.com/tulios/mappersmith-cached-gateway, following the protocol described at https://cloud.google.com/storage/docs/json_api/v1/how-tos/batch, requiring modifying the header `Content-Type` to `Content-Type: multipart/mixed;`. The function took a Gateway argument so it could be used on the browser and in node, but I've found the default gateways that come with mappersmith, on some occasions would deliberately override the headers I've specifically specified. It means it would prevent someone from specifying headers when they know what they're doing.

Also it looked like there was a typo with `this.opts.header` missing an `s` in `src/gateway/jquery-gateway.js`.

I don't know if this is a desirable change to you - I thought I'd send a pull request to see what you think.