### PR TITLE
Ommit the callback parameter when passing options to gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,12 @@ Client.Book.byId({id: 2}, function(data) {}, {
 })
 ```
 
+You can also ommit the second parameter (i.e. success callback), for example:
+
+```javascript
+Client.Book.starById({id: 2}, {xhrFields: {withCredentials: true}})
+```
+
 ### <a name="global-configurations-and-url-matching"></a> Global configurations and URL matching
 
 Imagine that you are using `Mappersmith.JQueryGateway` and all of your methods must be called with `jsonp` or use a special header, it will be incredibly boring add those configurations every time. Global configurations allow you to configure gateway options and a processor that will be used for every method. Keep in mind that the processor configured in the resource will be prioritized instead to global, for example:

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -109,6 +109,9 @@ Mapper.prototype = {
         opts = callback;
         callback = params;
         params = undefined;
+      } else if (callback && typeof callback !== 'function') {
+        opts = callback;
+        callback = Utils.noop;
       }
 
       if (!!descriptor.params) {

--- a/test/mapper-test.js
+++ b/test/mapper-test.js
@@ -228,6 +228,30 @@ describe('Mapper', function() {
       });
     });
 
+    describe('with params and opts but without callback', function() {
+      it('considers opts as the second argument', function() {
+        var opts = {jsonp: true};
+        var request = mapper.newGatewayRequest({
+          method: method,
+          host: host,
+          path: path
+        });
+        fullUrl = host + resolvedPath;
+
+        expect(request(params, opts)).to.be.an.instanceof(gateway);
+        expect(gateway.prototype.success).to.have.been.calledWith(Utils.noop);
+        expect(gateway.prototype.call).to.have.been.called;
+        expect(gateway).to.have.been.calledWith({
+          url: fullUrl,
+          host: host,
+          path: resolvedPath,
+          method: method,
+          opts: opts,
+          params: params,
+        });
+      });
+    })
+
     describe('with body param', function() {
       it('includes the value defined by bodyAttr in the key "body"', function() {
         mapper.bodyAttr = 'body';


### PR DESCRIPTION
When passing options for the gateway implementation you can ommit the callback parameter.