### PR TITLE
Use the same header level for 0.13.2 in a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 0.13.2
+## 0.13.2
 
   - bugfix: prioritizes user-defined content-type header even for post/put/patch/delete methods. `application/x-www-form-urlencoded` is not forced if Content-Type header is defined.
 


### PR DESCRIPTION
This makes changelog more consistent and fixes [parsing error](https://allmychanges.com/p/javascript/mappersmith/) at AllMyChanges.com.