### PR TITLE
Add a retry validation callback to the Retry Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,8 @@ setRetryConfigs({
   initialRetryTimeInSecs: 0.1,
   factor: 0.2, // randomization factor
   multiplier: 2, // exponential factor
-  retries: 5 // max retries
+  retries: 5, // max retries
+  validateRetry: () => true // a function that returns true if the request should be retried
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mappersmith",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "It is a lightweight rest client for node.js and the browser",
   "author": "Tulio Ornelas <ornelas.tulio@gmail.com>",
   "contributors": [

--- a/src/middleware/retry.js
+++ b/src/middleware/retry.js
@@ -8,7 +8,8 @@ let retryConfigs = {
   initialRetryTimeInSecs: 0.1,
   factor: 0.2, // randomization factor
   multiplier: 2, // exponential factor
-  retries: 5 // max retries
+  retries: 5, // max retries
+  validateRetry: () => true // a function that returns true if the request should be retried
 }
 
 /**
@@ -73,7 +74,7 @@ const retriableRequest = (resolve, reject, next) => {
         resolve(enhancedResponse(response, retryCount, retryTime))
       })
       .catch((response) => {
-        shouldRetry
+        shouldRetry && retryConfigs.validateRetry(response)
           ? scheduleRequest()
           : reject(enhancedResponse(response, retryCount, retryTime))
       })


### PR DESCRIPTION
Add a retry validation callback to the Retry Middleware so that the caller can decide if the request should be retried based on the failed response object.