### PR TITLE
Fix issue when mocking clients with middleware that use context

### DIFF
--- a/spec/browser/test/mock-resource.spec.js
+++ b/spec/browser/test/mock-resource.spec.js
@@ -1,4 +1,4 @@
-import forge from 'src/index'
+import forge, { setContext } from 'src/index'
 import MockAssert from 'src/mocks/mock-assert'
 import EncodeJsonMiddleware from 'src/middlewares/encode-json'
 import { getManifest, headerMiddleware } from 'spec/helper'
@@ -256,6 +256,45 @@ describe('Test lib / mock resources', () => {
           expect(response.headers()['x-middleware-phase']).toEqual('response')
           expect(response.headers()['x-resource-name']).toEqual('Blog')
           expect(response.headers()['x-resource-method']).toEqual('post')
+          done()
+        })
+        .catch((response) => {
+          done.fail(response.data())
+        })
+    })
+  })
+
+  describe('when client is using middlewares with context', () => {
+    let params
+
+    beforeEach(() => {
+      const ContextMiddleware = ({ context }) => ({
+        request: req => req.enhance({ headers: { 'x-context': context.headerFromContext } })
+      })
+      client = forge(getManifest([ContextMiddleware]))
+      params = {
+        body: {
+          title: 'blog title',
+          text: 'lorem ipsum'
+        }
+      }
+    })
+
+    it('executes the middlewares using context', (done) => {
+      mockClient(client)
+        .resource('Blog')
+        .method('post')
+        .with(params)
+        .status(200)
+        .response({ ok: true })
+
+      setContext({ headerFromContext: 'header from context' })
+
+      client.Blog
+        .post(params)
+        .then((response) => {
+          expect(response.status()).toEqual(200)
+          expect(response.request().headers()['x-context']).toEqual('header from context')
           done()
         })
         .catch((response) => {

--- a/src/client-builder.js
+++ b/src/client-builder.js
@@ -20,11 +20,7 @@ function ClientBuilder (manifest, GatewayClassFactory, configs) {
     )
   }
 
-  const defaultGatewayConfigs = configs.gatewayConfigs
-  const defaultMiddleware = configs.middleware
-  this.context = configs.context
-
-  this.manifest = new Manifest(manifest, defaultGatewayConfigs, defaultMiddleware)
+  this.manifest = new Manifest(manifest, configs)
   this.GatewayClassFactory = GatewayClassFactory
 }
 
@@ -49,8 +45,7 @@ ClientBuilder.prototype = {
   },
 
   invokeMiddlewares (resourceName, resourceMethod, initialRequest) {
-    const context = assign({}, this.context)
-    const middleware = this.manifest.createMiddleware({ resourceName, resourceMethod, context })
+    const middleware = this.manifest.createMiddleware({ resourceName, resourceMethod })
     const finalRequest = middleware
       .reduce((request, middleware) => middleware.request(request), initialRequest)
 

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -9,14 +9,15 @@ import { assign } from './utils'
  *   @param {Object} obj.resources - default: {}
  *   @param {Array}  obj.middleware or obj.middlewares - default: []
  */
-function Manifest (obj, defaultGatewayConfigs = null, defaultMiddleware = []) {
+function Manifest (obj, { gatewayConfigs = null, middleware = [], context = {} }) {
   this.host = obj.host
   this.clientId = obj.clientId || null
-  this.gatewayConfigs = assign({}, defaultGatewayConfigs, obj.gatewayConfigs)
+  this.gatewayConfigs = assign({}, gatewayConfigs, obj.gatewayConfigs)
   this.resources = obj.resources || {}
+  this.context = context
 
   // TODO: deprecate obj.middlewares in favor of obj.middleware
-  this.middleware = [...(obj.middleware || obj.middlewares || []), ...defaultMiddleware]
+  this.middleware = [...(obj.middleware || obj.middlewares || []), ...middleware]
 }
 
 Manifest.prototype = {
@@ -66,7 +67,7 @@ Manifest.prototype = {
     const createInstance = (middlewareFactory) => assign({
       request: (request) => request,
       response: (next) => next()
-    }, middlewareFactory(assign(args, { clientId: this.clientId })))
+    }, middlewareFactory(assign(args, { clientId: this.clientId, context: assign({}, this.context) })))
 
     return this.middleware.map(createInstance)
   }


### PR DESCRIPTION
The way I fixed it doesn't require changes to the mock-resource, so I think it's optimal.