### PR TITLE
Support async middleware request phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 node_js:
   - "8"
   - "7"
-  - "6"
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -378,6 +378,20 @@ client.User.all()
 // context: {}
 ```
 
+__NOTE__: The request phase can be asynchronous, just return a promise resolving a request. Example:
+
+```javascript
+const MyMiddleware = () => ({
+  request(request) {
+    return Promise.resolve(
+      request.enhance({
+        headers: { 'x-special-token': 'abc123' }
+      })
+    )
+  }
+})
+```
+
 ### <a name="global-middleware"></a> Global middleware
 
 Middleware can also be defined globally, so new clients will automatically

--- a/spec/browser/client-builder.spec.js
+++ b/spec/browser/client-builder.spec.js
@@ -18,6 +18,7 @@ describe('ClientBuilder', () => {
     gatewayInstance = { call: jest.fn() }
     gatewayClass = jest.fn(() => gatewayInstance)
     configs = {
+      Promise,
       gatewayConfigs: {
         gateway: 'configs'
       },
@@ -41,14 +42,15 @@ describe('ClientBuilder', () => {
     expect(client._manifest instanceof Manifest).toEqual(true)
   })
 
-  it('accepts custom gatewayConfigs', () => {
+  it('accepts custom gatewayConfigs', async () => {
     const customGatewayConfigs = { custom: 'configs' }
     manifest = getManifest([], customGatewayConfigs)
     clientBuilder = new ClientBuilder(manifest, GatewayClassFactory, configs)
     client = clientBuilder.build()
 
-    gatewayInstance.call.mockReturnValue('Promise')
-    expect(client.User.byId({ id: 1 })).toEqual('Promise')
+    gatewayInstance.call.mockReturnValue(Promise.resolve('value'))
+    const response = await client.User.byId({ id: 1 })
+    expect(response).toEqual('value')
     expect(gatewayClass).toHaveBeenCalledWith(expect.any(Request), expect.objectContaining({
       custom: 'configs',
       gateway: 'configs'
@@ -58,9 +60,10 @@ describe('ClientBuilder', () => {
   })
 
   describe('when a resource method is called', () => {
-    it('calls the gateway with the correct request', () => {
-      gatewayInstance.call.mockReturnValue('Promise')
-      expect(client.User.byId({ id: 1 })).toEqual('Promise')
+    it('calls the gateway with the correct request', async () => {
+      gatewayInstance.call.mockReturnValue(Promise.resolve('value'))
+      const response = await client.User.byId({ id: 1 })
+      expect(response).toEqual('value')
       expect(gatewayClass).toHaveBeenCalledWith(expect.any(Request), configs.gatewayConfigs)
       expect(gatewayInstance.call).toHaveBeenCalled()
 

--- a/spec/browser/mappersmith.spec.js
+++ b/spec/browser/mappersmith.spec.js
@@ -33,7 +33,7 @@ describe('mappersmith', () => {
         }
       }
 
-      gatewayInstance = { call: jest.fn() }
+      gatewayInstance = { call: jest.fn(() => Promise.resolve('response')) }
       gatewayClass = jest.fn(() => gatewayInstance)
     })
 
@@ -41,32 +41,32 @@ describe('mappersmith', () => {
       configs.gateway = originalConfig
     })
 
-    it('builds a new client with the configured gateway', () => {
+    it('builds a new client with the configured gateway', async () => {
       configs.gateway = gatewayClass
 
       const client = forge(manifest)
       expect(client.Test).toEqual(expect.any(Object))
       expect(client.Test.method).toEqual(expect.any(Function))
 
-      client.Test.method()
+      await client.Test.method()
       expect(gatewayClass).toHaveBeenCalled()
       expect(gatewayInstance.call).toHaveBeenCalled()
     })
 
     describe('when config.gateway changes', () => {
-      it('make calls using the new configuration', () => {
+      it('make calls using the new configuration', async () => {
         configs.gateway = gatewayClass
         const client = forge(manifest)
 
-        client.Test.method()
+        await client.Test.method()
         expect(gatewayClass).toHaveBeenCalled()
         expect(gatewayClass.mock.calls.length).toEqual(1)
 
-        const newGatewayInstance = { call: jest.fn() }
+        const newGatewayInstance = { call: jest.fn(() => Promise.resolve('response')) }
         const newGatewayClass = jest.fn(() => newGatewayInstance)
         configs.gateway = newGatewayClass
 
-        client.Test.method()
+        await client.Test.method()
         expect(newGatewayClass).toHaveBeenCalled()
         expect(gatewayClass.mock.calls.length).toEqual(1)
       })

--- a/spec/browser/test/mock-resource.spec.js
+++ b/spec/browser/test/mock-resource.spec.js
@@ -75,7 +75,7 @@ describe('Test lib / mock resources', () => {
     })
   })
 
-  it('triggers the catch block on http errors', (done) => {
+  it('triggers the catch block on http errors', async () => {
     mockClient(client)
       .resource('User')
       .method('byId')
@@ -83,15 +83,12 @@ describe('Test lib / mock resources', () => {
       .status(422)
       .response({ invalid: true })
 
-    client.User.byId({ id: 1 }).then((response) => {
-      const error = response.rawData ? response.rawData() : response
-      done.fail(`Expected this request to fail: ${error}`)
-    })
-    .catch((response) => {
+    try {
+      await client.User.byId({ id: 1 })
+    } catch (response) {
       expect(response.status()).toEqual(422)
       expect(response.data()).toEqual({ invalid: true })
-      done()
-    })
+    }
   })
 
   it('works with different http methods', (done) => {


### PR DESCRIPTION
If the request phase returns a promise it will be chained as usual

Example:
```javascript
const MyMiddleware = () => ({
  request(req) {
    return Promise.resolve(req.enhance({ headers: { token: 'abc' } }))
  }
})
```

- [x] Add support to async middleware request phase
- [x] Update documentation

@carlrygart @ticolucci