### PR TITLE
Retry on success

### DIFF
--- a/spec/browser/request.spec.js
+++ b/spec/browser/request.spec.js
@@ -138,6 +138,14 @@ describe('Request', () => {
     })
   })
 
+  describe('#header', () => {
+    it('returns the value of the given header name', () => {
+      methodDescriptor.headers = { Authorization: 'token-123' }
+      const request = new Request(methodDescriptor)
+      expect(request.header('authorization')).toEqual('token-123')
+    })
+  })
+
   describe('#body', () => {
     it('returns the configured body param from params', () => {
       methodDescriptor.bodyAttr = 'differentParam'

--- a/src/client-builder.js
+++ b/src/client-builder.js
@@ -23,6 +23,7 @@ function ClientBuilder (manifest, GatewayClassFactory, configs) {
   this.Promise = configs.Promise
   this.manifest = new Manifest(manifest, configs)
   this.GatewayClassFactory = GatewayClassFactory
+  this.maxMiddlewareStackExecutionAllowed = configs.maxMiddlewareStackExecutionAllowed
 }
 
 ClientBuilder.prototype = {
@@ -49,25 +50,38 @@ ClientBuilder.prototype = {
     const middleware = this.manifest.createMiddleware({ resourceName, resourceMethod })
     const GatewayClass = this.GatewayClassFactory()
     const gatewayConfigs = this.manifest.gatewayConfigs
+
     const chainRequestPhase = (requestPromise, middleware) => {
       return requestPromise
         .then(request => middleware.request(request))
         .then(request => this.Promise.resolve(request))
     }
-    const chainResponsePhase = (next, middleware) => () => middleware.response(next)
+
+    let executions = 0
+
+    const executeMiddlewareStack = () => middleware
+      .reduce(
+        chainRequestPhase,
+        this.Promise.resolve(initialRequest)
+      )
+      .then(finalRequest => {
+        executions++
+
+        if (executions > this.maxMiddlewareStackExecutionAllowed) {
+          throw new Error(
+            `[Mappersmith] infinite loop detected (middleware stack invoked ${executions} times). Check the use of "renew" in one of the middleware.`
+          )
+        }
+
+        const chainResponsePhase = (next, middleware) => () => middleware.response(next, executeMiddlewareStack)
+        const callGateway = () => new GatewayClass(finalRequest, gatewayConfigs).call()
+        const execute = middleware.reduce(chainResponsePhase, callGateway)
+        return execute()
+      })
 
     return new this.Promise((resolve, reject) => {
-      return middleware
-        .reduce(
-          chainRequestPhase,
-          this.Promise.resolve(initialRequest)
-        )
-        .then(finalRequest => {
-          const callGateway = () => new GatewayClass(finalRequest, gatewayConfigs).call()
-          const execute = middleware.reduce(chainResponsePhase, callGateway)
-
-          return execute().then(response => resolve(response))
-        })
+      executeMiddlewareStack()
+        .then(response => resolve(response))
         .catch(reject)
     })
   }

--- a/src/mappersmith.js
+++ b/src/mappersmith.js
@@ -11,6 +11,17 @@ export const configs = {
   fetch: typeof fetch === 'function' ? fetch : null, // eslint-disable-line no-undef
 
   /**
+   * The maximum amount of executions allowed before it is considered an infinite loop.
+   * In the response phase of middleware, it's possible to execute a function called "renew",
+   * which can be used to rerun the middleware stack. This feature is useful in some scenarios,
+   * for example, re-fetching an invalid access token.
+
+   * This configuration is used to detect infinite loops, don't increase this value too much
+   * @default 2
+   */
+  maxMiddlewareStackExecutionAllowed: 2,
+
+  /**
    * Gateway implementation, it defaults to "lib/gateway/xhr" for browsers and
    * "lib/gateway/http" for node
    */

--- a/src/middleware/retry/v2/index.js
+++ b/src/middleware/retry/v2/index.js
@@ -66,7 +66,9 @@ const retriableRequest = (resolve, reject, next) => {
 
     next()
       .then((response) => {
-        resolve(enhancedResponse(response, retryConfigs.headerRetryCount, retryCount, retryConfigs.headerRetryTime, retryTime))
+        shouldRetry && retryConfigs.validateRetry(response)
+          ? scheduleRequest()
+          : resolve(enhancedResponse(response, retryConfigs.headerRetryCount, retryCount, retryConfigs.headerRetryTime, retryTime))
       })
       .catch((response) => {
         shouldRetry && retryConfigs.validateRetry(response)

--- a/src/request.js
+++ b/src/request.js
@@ -129,6 +129,17 @@ Request.prototype = {
     )
   },
 
+  /**
+   * Utility method to get a header value by name
+   *
+   * @param {String} name
+   *
+   * @return {String|Undefined}
+   */
+  header (name) {
+    return this.headers()[name.toLowerCase()]
+  },
+
   body () {
     return this.requestParams[this.methodDescriptor.bodyAttr]
   },


### PR DESCRIPTION
We would want to trigger retry middleware on success as well, because there might be cases when its needed. For example 202 response, that is indication that retry is required