### PR TITLE
Improve network errors handling

### DIFF
--- a/spec/integration/browser/integration.spec.js
+++ b/spec/integration/browser/integration.spec.js
@@ -4,7 +4,7 @@ import md5 from 'js-md5'
 
 import integrationTestsForGateway from 'spec/integration/shared-examples'
 import createManifest from 'spec/integration/support/manifest'
-import { errorMessage } from 'spec/integration/support'
+import { errorMessage, INVALID_ADDRESS } from 'spec/integration/support'
 
 import XHR from 'src/gateway/xhr'
 import Fetch from 'src/gateway/fetch'
@@ -38,16 +38,32 @@ describe('integration', () => {
         })
       })
     })
+
+    describe('on network errors', () => {
+      it('returns the original error', (done) => {
+        const Client = forge(createManifest(INVALID_ADDRESS), gateway)
+        Client.PlainText.get().then((response) => {
+          done.fail(`Expected this request to fail: ${errorMessage(response)}`)
+        })
+        .catch((response) => {
+          expect(response.status()).toEqual(400)
+          expect(response.error()).toMatch(/failed to fetch/i)
+          done()
+        })
+      })
+    })
   })
 
   describe('XHR', () => {
     const gateway = XHR
     const params = { host: '/proxy' }
+
     integrationTestsForGateway(gateway, params, (gateway, params) => {
       describe('file upload', () => {
         fileUploadSpec(forge(createManifest(params.host), gateway))
       })
     })
+
     describe('with raw binary', () => {
       it('GET /api/binary.pdf', (done) => {
         const Client = forge(createManifest(params.host), gateway)
@@ -62,6 +78,20 @@ describe('integration', () => {
         })
         .catch((response) => {
           done.fail(`test failed with promise error: ${errorMessage(response)}`)
+        })
+      })
+    })
+
+    describe('on network errors', () => {
+      it('returns the original error', (done) => {
+        const Client = forge(createManifest(INVALID_ADDRESS), gateway)
+        Client.PlainText.get().then((response) => {
+          done.fail(`Expected this request to fail: ${errorMessage(response)}`)
+        })
+        .catch((response) => {
+          expect(response.status()).toEqual(400)
+          expect(response.error()).toMatch(/network error/i)
+          done()
         })
       })
     })

--- a/spec/integration/browser/integration.spec.js
+++ b/spec/integration/browser/integration.spec.js
@@ -47,7 +47,7 @@ describe('integration', () => {
         })
         .catch((response) => {
           expect(response.status()).toEqual(400)
-          expect(response.error()).toMatch(/failed to fetch/i)
+          expect(response.error()).toMatch(/Error/i)
           done()
         })
       })

--- a/spec/integration/node/integration.spec.js
+++ b/spec/integration/node/integration.spec.js
@@ -5,13 +5,15 @@ import integrationTestsForGateway from 'spec/integration/shared-examples'
 import HTTP from 'src/gateway/http'
 import forge from 'src/index'
 import createManifest from 'spec/integration/support/manifest'
-import { errorMessage } from 'spec/integration/support'
+import { errorMessage, INVALID_ADDRESS } from 'spec/integration/support'
 
 describe('integration', () => {
   describe('HTTP', () => {
     const gateway = HTTP
     const params = { host: 'http://localhost:9090' }
+
     integrationTestsForGateway(gateway, params)
+
     describe('with raw binary', () => {
       it('GET /api/binary.pdf', (done) => {
         const Client = forge(createManifest(params.host), gateway)
@@ -22,6 +24,20 @@ describe('integration', () => {
         })
         .catch((response) => {
           done.fail(`test failed with promise error: ${errorMessage(response)}`)
+        })
+      })
+    })
+
+    describe('on network errors', () => {
+      it('returns the original error', (done) => {
+        const Client = forge(createManifest(INVALID_ADDRESS), gateway)
+        Client.PlainText.get().then((response) => {
+          done.fail(`Expected this request to fail: ${errorMessage(response)}`)
+        })
+        .catch((response) => {
+          expect(response.status()).toEqual(400)
+          expect(response.error()).toMatch(/ENOTFOUND/i)
+          done()
         })
       })
     })

--- a/spec/integration/support/index.js
+++ b/spec/integration/support/index.js
@@ -1,3 +1,5 @@
+export const INVALID_ADDRESS = 'http://mappersmith.test'
+
 export function debugResponse (response) {
   const request = response.request()
   return `Status: ${response.status()}, Headers: ${JSON.stringify(request.headers())}, ${request.method().toUpperCase()} ${request.url()} => ${response.rawData()}`

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -37,7 +37,7 @@ Gateway.prototype = {
       try {
         this[this.request.method()].apply(this, arguments)
       } catch (e) {
-        this.dispatchClientError(e.message)
+        this.dispatchClientError(e.message, e)
       }
     })
   },
@@ -48,8 +48,8 @@ Gateway.prototype = {
       : this.failCallback(response)
   },
 
-  dispatchClientError (message) {
-    this.failCallback(new Response(this.request, 400, message))
+  dispatchClientError (message, error) {
+    this.failCallback(new Response(this.request, 400, message, {}, [error]))
   },
 
   prepareBody (method, headers) {

--- a/src/gateway/fetch.js
+++ b/src/gateway/fetch.js
@@ -69,7 +69,8 @@ Fetch.prototype = Gateway.extends({
     if (timeout) {
       timer = setTimeout(() => {
         canceled = true
-        this.dispatchClientError(`Timeout (${timeout}ms)`)
+        const error = new Error(`Timeout (${timeout}ms)`)
+        this.dispatchClientError(error.message, error)
       }, timeout)
     }
 
@@ -102,7 +103,7 @@ Fetch.prototype = Gateway.extends({
         }
 
         clearTimeout(timer)
-        this.dispatchClientError(error.message)
+        this.dispatchClientError(error.message, error)
       })
   },
 

--- a/src/gateway/http.js
+++ b/src/gateway/http.js
@@ -77,7 +77,8 @@ HTTP.prototype = Gateway.extends({
     if (timeout) {
       httpRequest.setTimeout(timeout, () => {
         this.canceled = true
-        this.dispatchClientError(`Timeout (${timeout}ms)`)
+        const error = new Error(`Timeout (${timeout}ms)`)
+        this.dispatchClientError(error.message, error)
       })
     }
 
@@ -107,7 +108,7 @@ HTTP.prototype = Gateway.extends({
       return
     }
 
-    this.dispatchClientError(e.message)
+    this.dispatchClientError(e.message, e)
   },
 
   createResponse (httpResponse, rawData) {

--- a/src/gateway/xhr.js
+++ b/src/gateway/xhr.js
@@ -81,13 +81,20 @@ XHR.prototype = Gateway.extends({
       this.dispatchResponse(this.createResponse(xmlHttpRequest))
     })
 
-    xmlHttpRequest.addEventListener('error', () => {
+    xmlHttpRequest.addEventListener('error', (e) => {
       if (this.canceled) {
         return
       }
 
       clearTimeout(this.timer)
-      this.dispatchClientError('Network error')
+      const guessedErrorCause = e
+          ? e.message || e.name
+          : xmlHttpRequest.responseText
+
+      const errorMessage = 'Network error'
+      const enhancedMessage = guessedErrorCause ? `: ${guessedErrorCause}` : ''
+      const error = new Error(`${errorMessage}${enhancedMessage}`)
+      this.dispatchClientError(errorMessage, error)
     })
 
     const xhrOptions = this.options().XHR


### PR DESCRIPTION
XHR can't provide useful information on network errors, but luckily, platforms like react-native or the fetch gateway can offer better granularity on what is happening. This PR  introduces a new method to the `Response` object to return the last error on the stack. As usual, the middleware can add more errors to the stack and improve the error traceability.

On the gateway side, `dispatchClientError (message, error)` now receives the error instance as a second argument.

This PR solves issue #98 and can improve custom gateway implementations

^ @oblador @wisko