### PR TITLE
Allow setting of some resource configs at manifest level

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ client.Blog.create({
 ```
 
 __NOTE__: It's possible to post body as JSON, check the [EncodeJsonMiddleware](#encode-json-middleware) below for more information
+__NOTE__: The `bodyAttr` param can be set at manifest level.
 
 ### <a name="headers"></a> Headers
 
@@ -231,6 +232,8 @@ If `headers` is not possible as a special parameter for your API you can configu
 
 client.User.all({ h: { Authorization: 'token 1d1435k' } })
 ```
+
+__NOTE__: The `headersAttr` param can be set at manifest level.
 
 ### <a name="basic-auth"></a> Basic auth
 
@@ -256,6 +259,7 @@ client.User.all({ secret: { username: 'bob', password: 'bob' } })
 ```
 
 __NOTE__: A default basic auth can be configured with the use of the [BasicAuthMiddleware](#basic-auth-middleware), check the middleware section below for more information.
+__NOTE__: The `authAttr` param can be set at manifest level.
 
 ### <a name="timeout"></a> Timeout
 
@@ -278,6 +282,7 @@ client.User.all({ maxWait: 500 })
 ```
 
 __NOTE__: A default timeout can be configured with the use of the [TimeoutMiddleware](#timeout-middleware), check the middleware section below for more information.
+__NOTE__: The `timeoutAttr` param can be set at manifest level.
 
 ### <a name="alternative-host"></a> Alternative host
 

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -123,4 +123,22 @@ export const getManifest = (middleware = [], gatewayConfigs = null, clientId = n
   }
 })
 
+export const getManifestWithResourceConf = (middleware = [], gatewayConfigs = null, clientId = null) => ({
+  clientId,
+  host: 'http://example.org',
+  bodyAttr: 'customAttr',
+  gatewayConfigs,
+  middleware,
+  resources: {
+    User: {
+      all: { path: '/users' },
+      byId: { path: '/users/{id}' }
+    },
+    Blog: {
+      post: { method: 'post', path: '/blogs' },
+      addComment: { method: 'put', path: '/blogs/{id}/comment' }
+    }
+  }
+})
+
 export const createRequest = (args = {}) => new Request(new MethodDescriptor(args))

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -13,6 +13,10 @@ import { assign } from './utils'
  */
 function Manifest (obj, { gatewayConfigs = null, middleware = [], context = {} }) {
   this.host = obj.host
+  this.bodyAttr = obj.bodyAttr
+  this.headersAttr = obj.headersAttr
+  this.authAttr = obj.authAttr
+  this.timeoutAttr = obj.timeoutAttr
   this.clientId = obj.clientId || null
   this.gatewayConfigs = assign({}, gatewayConfigs, obj.gatewayConfigs)
   this.resources = obj.resources || {}
@@ -55,10 +59,15 @@ Manifest.prototype = {
       )
     }
 
-    return new MethodDescriptor(assign(
-      { host: this.host },
-      definition
-    ))
+    return new MethodDescriptor(
+      assign({
+        host: this.host,
+        bodyAttr: this.bodyAttr,
+        headersAttr: this.headersAttr,
+        authAttr: this.authAttr,
+        timeoutAttr: this.timeoutAttr
+      }, definition)
+    )
   },
 
   /**


### PR DESCRIPTION
This fixes #56 

It allows setting of the bodyAttr param at manifest level so that it is not repeated for every resource if it is always different from 'body'