### PR TITLE
Fix invalid query string when path already contains query string

### DIFF
--- a/spec/browser/request.spec.js
+++ b/spec/browser/request.spec.js
@@ -66,6 +66,13 @@ describe('Request', () => {
       expect(path).toEqual('/api/example.json?id=1&title=test')
     })
 
+    it('appends the query string with a leading & if the path has a hard-coded query string', () => {
+      methodDescriptor.path = '/api/example.json?id=1'
+      methodDescriptor.params = { title: 'test' }
+      const path = new Request(methodDescriptor).path()
+      expect(path).toEqual('/api/example.json?id=1&title=test')
+    })
+
     it('renames the params according to their queryParamAlias when appending them to the query string', () => {
       methodDescriptor.path = '/api/example.json'
       methodDescriptor.params = { userId: 1, transactionId: 2 }

--- a/src/request.js
+++ b/src/request.js
@@ -104,7 +104,8 @@ Request.prototype = {
 
     const queryString = toQueryString(aliasedParams)
     if (queryString.length !== 0) {
-      path += `?${queryString}`
+      const hasQuery = path.includes('?')
+      path += `${hasQuery ? '&' : '?'}${queryString}`
     }
 
     return path


### PR DESCRIPTION
I will hold until my last breath that a query string is delimited by a single question mark, and that the query part is entirely opaque (https://tools.ietf.org/html/rfc3986#section-3.4), but since apparently some clients barf if you give them a query string containing multiple question marks instead of ampersands, here we are.