### PR TITLE
Fix "ReferenceError: regeneratorRuntime is not defined"

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -74,13 +74,11 @@ export const clear = () => {
  * @return {Promise<Response>}
  * @throws Will throw an error if it doesn't find a mock to match the given request
  */
-export const lookupResponseAsync = async (request) => {
+export const lookupResponseAsync = (request) => {
   const mocksPendingMiddlewareExecution = store.filter(mock => mock.pendingMiddlewareExecution)
-  await configs.Promise.all(
-    mocksPendingMiddlewareExecution.map(async mock => mock.executeMiddlewareStack())
-  )
-
-  return lookupResponse(request)
+  return configs
+    .Promise.all(mocksPendingMiddlewareExecution.map(mock => mock.executeMiddlewareStack()))
+    .then(() => lookupResponse(request))
 }
 
 /**


### PR DESCRIPTION
Mappersmith versions `2.27.0` and `2.27.1` might throw `ReferenceError: regeneratorRuntime is not defined` when importing the test library (`mappersmith/test`) on environments without a transpiler. There was an async function that is now replaced by a regular Promise.