### PR TITLE
Add first draft for a TypeScript support to the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ __Mappersmith__ is a lightweight rest client for node.js and the browser. It cre
       - [Timeout](#middleware-timeout)
   - [Testing Mappersmith](#testing-mappersmith)
   - [Gateways](#gateways)
+  - [TypeScript](#typescript)
 - [Development](#development)
 
 ## <a name="installation"></a> Installation
@@ -1146,6 +1147,64 @@ configs.gatewayConfigs.Fetch = {
 ```
 
 Take a look [here](https://github.com/tulios/mappersmith/blob/master/src/mappersmith.js) for more options.
+
+### <a name="typescript"></a> TypeScript
+
+__Mappersmith__ also supports TypeScript (>=3.5). In the following sections there are some common examples for using TypeScript with Mappersmith where it is not too obvious how typings are properly applied.
+
+#### Create a middleware with TypeScript
+
+To create a middleware using TypeScript you just have to add the `Middleware` interface to your middleware object:
+
+```typescript
+import { Middleware } from 'mappersmith'
+
+const MyMiddleware: Middleware = () => ({
+  prepareRequest(next) {
+    return next().then(request => request.enhance({
+      headers: { 'x-special-request': '->' }
+    }))
+  },
+
+  response(next) {
+    return next().then(response => response.enhance({
+      headers: { 'x-special-response': '<-' }
+    }))
+  }
+})
+```
+
+#### Use the `mockClient` with TypeScript
+
+To use the `mockClient` with proper types you need to pass a typeof your client as generic to the `mockClient` function:
+
+```typescript
+import forge from 'mappersmith'
+import { mockClient } from 'mappersmith/test'
+
+const github = forge({
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {
+    Status: {
+      current: { path: '/api/status.json' },
+      messages: { path: '/api/messages.json' },
+      lastMessage: { path: '/api/last-message.json' },
+    },
+  },
+})
+
+const mock = mockClient<typeof github>(github)
+  .resource('Status')
+  .method('current')
+  .with({ id: 'abc' })
+  .response({ allUsers: [] })
+  .assertObject()
+
+console.log(mock.mostRecentCall())
+console.log(mock.callsCount())
+console.log(mock.calls())
+```
 
 ## <a name="development"></a> Development
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "Mathias Klippinge <mathias.klippinge@gmail.com>"
   ],
   "main": "index.js",
+  "types": "typings/index.d.ts",
   "scripts": {
     "integration-server": "node spec/integration/server.js",
     "test:browser": "./node_modules/.bin/jest --config jestSetup/configs/config.web.json",
@@ -17,6 +18,7 @@
     "test:node": "./node_modules/.bin/jest --config jestSetup/configs/config.node.json",
     "test:node:integration": "cross-env NODE_ENV=test cross-env NODE_PATH=. cross-env JASMINE_CONFIG_PATH=spec/integration/node/support/jasmine.json jasmine",
     "test:node:watch": "./node_modules/.bin/jest --config jestSetup/configs/config.node.json --watchAll",
+    "test:typings": "./node_modules/.bin/tsc",
     "test": "concurrently --success first --names \"test,server\" --kill-others \"node scripts/ci.js\" \"yarn integration-server\"",
     "build:node": "rm -rf lib/* && ./node_modules/.bin/babel src -d lib",
     "build:browser": "rm -rf dist/* && ./node_modules/.bin/webpack --config webpack.conf.js",
@@ -85,6 +87,7 @@
     "mockdate": "^2.0.1",
     "multer": "^1.2.0",
     "puppeteer": "^0.12.0",
+    "typescript": "^3.5.2",
     "uglifyjs-webpack-plugin": "^2.1.1",
     "webpack": "^4.28.1",
     "webpack-cli": "^3.2.1",

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -10,5 +10,6 @@ function exec (command, cwd) {
 exec('yarn lint', rootDir)
 exec('yarn test:browser', rootDir)
 exec('yarn test:node', rootDir)
+exec('yarn test:typings', rootDir)
 exec('cross-env SINGLE_RUN=true yarn test:browser:integration', rootDir)
 exec('cross-env SINGLE_RUN=true yarn test:node:integration', rootDir)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,5 +2,5 @@
 set -euv
 
 sh -c "NODE_ENV=production npm run build"
-cp example.js LICENSE README.md package.json lib/
+cp -r example.js LICENSE README.md package.json typings lib/
 sh -c "cd lib; npm publish"

--- a/spec/typescript/basic.spec.ts
+++ b/spec/typescript/basic.spec.ts
@@ -1,0 +1,17 @@
+import forge from 'mappersmith'
+
+const github = forge({
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {
+    Status: {
+      current: { path: '/api/status.json' },
+      messages: { path: '/api/messages.json' },
+      lastMessage: { path: '/api/last-message.json' }
+    }
+  }
+})
+
+github.Status.lastMessage({ randomParam: 10, another: { foo: "hi" } }).then((response) => {
+  console.log(`status: ${response.data()}`)
+})

--- a/spec/typescript/config.spec.ts
+++ b/spec/typescript/config.spec.ts
@@ -1,0 +1,38 @@
+import { configs, setContext, Middleware } from 'mappersmith'
+
+const MyMiddleware: Middleware = () => ({
+  prepareRequest(next) {
+    return next().then(response => response.enhance({
+      headers: { 'x-special-request': '->' }
+    }))
+  },
+
+  response(next) {
+    return next().then(response => response.enhance({
+      headers: { 'x-special-response': '<-' }
+    }))
+  }
+})
+
+setContext({ some: 'data'})
+
+configs.maxMiddlewareStackExecutionAllowed = 2
+configs.middleware = [MyMiddleware]
+configs.fetch = fetch
+configs.gatewayConfigs.Mock = {}
+configs.gatewayConfigs.Fetch = {
+  credentials: 'same-origin'
+}
+configs.gatewayConfigs.HTTP = {
+  configure() {
+    return {
+      agent: "something"
+    }
+  }
+}
+configs.gatewayConfigs.XHR = {
+  withCredentials: true,
+  configure(xhr) {
+    xhr.ontimeout = () => console.error('timeout!')
+  }
+}

--- a/spec/typescript/deprecated-middleware.spec.ts
+++ b/spec/typescript/deprecated-middleware.spec.ts
@@ -1,0 +1,32 @@
+import forge, {Middleware} from 'mappersmith'
+
+const MyMiddleware: Middleware = () => ({
+  request(request) {
+    return request.enhance({
+      headers: { 'x-special-request': '->' }
+    })
+  },
+
+  response(next) {
+    return next().then((response) => response.enhance({
+      headers: { 'x-special-response': '<-' }
+    }))
+  }
+})
+
+const github = forge({
+  clientId: 'github',
+  host: 'https://status.github.com',
+  middleware: [MyMiddleware],
+  resources: {
+    Status: {
+      current: { path: '/api/status.json' },
+      messages: { path: '/api/messages.json' },
+      lastMessage: { path: '/api/last-message.json' }
+    }
+  }
+})
+
+github.Status.lastMessage().then((response) => {
+  console.log(`status: ${response.data()}`)
+})

--- a/spec/typescript/gateway/fetch.spec.ts
+++ b/spec/typescript/gateway/fetch.spec.ts
@@ -1,0 +1,8 @@
+import FetchGateway from 'mappersmith/gateway/fetch'
+import { configs } from 'mappersmith'
+
+configs.gateway = FetchGateway
+
+configs.gatewayConfigs.Fetch = {
+  credentials: 'same-origin'
+}

--- a/spec/typescript/middleware.spec.ts
+++ b/spec/typescript/middleware.spec.ts
@@ -1,0 +1,56 @@
+import forge, {Middleware, MiddlewareParams} from 'mappersmith'
+
+const MyMiddleware: Middleware = () => ({
+  prepareRequest(next) {
+    return next().then(response => response.enhance({
+      headers: { 'x-special-request': '->' }
+    }))
+  },
+
+  response(next) {
+    return next().then(response => response.enhance({
+      headers: { 'x-special-response': '<-' }
+    }))
+  }
+})
+
+const MyMiddlewareWithOptions: Middleware = ({ resourceName, resourceMethod, context, clientId }: MiddlewareParams) => {
+  console.log({ resourceName, resourceMethod, context, clientId })
+  return {}
+}
+
+const MyMiddlewareWithSecondArgument: Middleware = () => ({
+  prepareRequest(next, abort) {
+    return next().then(request =>
+      request.header('x-special')
+        ? request
+        : abort(new Error('"x-special" must be set!'))
+    )
+  },
+  response(next, renew) {
+    return next().catch(response => {
+      if (response.status() === 401) {
+        return renew()
+      }
+
+      return next()
+    })
+  }
+})
+
+const github = forge({
+  clientId: 'github',
+  host: 'https://status.github.com',
+  middleware: [MyMiddleware, MyMiddlewareWithOptions, MyMiddlewareWithSecondArgument],
+  resources: {
+    Status: {
+      current: { path: '/api/status.json' },
+      messages: { path: '/api/messages.json' },
+      lastMessage: { path: '/api/last-message.json' }
+    }
+  }
+})
+
+github.Status.lastMessage().then((response) => {
+  console.log(`status: ${response.data()}`)
+})

--- a/spec/typescript/middleware/basic-auth.spec.ts
+++ b/spec/typescript/middleware/basic-auth.spec.ts
@@ -1,0 +1,11 @@
+import forge from 'mappersmith'
+import BasicAuthMiddleware from 'mappersmith/middleware/basic-auth'
+
+const BasicAuth = BasicAuthMiddleware({ username: 'bob', password: 'bob' })
+
+const client = forge({
+  middleware: [ BasicAuth ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/middleware/csrf.spec.ts
+++ b/spec/typescript/middleware/csrf.spec.ts
@@ -1,0 +1,9 @@
+import forge from 'mappersmith'
+import CSRF from 'mappersmith/middleware/csrf'
+
+const client = forge({
+  middleware: [ CSRF('csrfToken', 'x-csrf-token') ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/middleware/duration.spec.ts
+++ b/spec/typescript/middleware/duration.spec.ts
@@ -1,0 +1,9 @@
+import forge from 'mappersmith'
+import Duration from 'mappersmith/middleware/duration'
+
+const client = forge({
+  middleware: [ Duration ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/middleware/encode-json.spec.ts
+++ b/spec/typescript/middleware/encode-json.spec.ts
@@ -1,0 +1,9 @@
+import forge from 'mappersmith'
+import EncodeJson from 'mappersmith/middleware/encode-json'
+
+const client = forge({
+  middleware: [ EncodeJson ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/middleware/global-error-handler.spec.ts
+++ b/spec/typescript/middleware/global-error-handler.spec.ts
@@ -1,0 +1,14 @@
+import forge from 'mappersmith'
+import GlobalErrorHandler, { setErrorHandler } from 'mappersmith/middleware/global-error-handler'
+
+setErrorHandler((response) => {
+  console.log('global error handler')
+  return response.status() === 500
+})
+
+const client = forge({
+  middleware: [ GlobalErrorHandler ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/middleware/log.spec.ts
+++ b/spec/typescript/middleware/log.spec.ts
@@ -1,0 +1,9 @@
+import forge from 'mappersmith'
+import Log from 'mappersmith/middleware/log'
+
+const client = forge({
+  middleware: [ Log ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/middleware/retry-v2.spec.ts
+++ b/spec/typescript/middleware/retry-v2.spec.ts
@@ -1,0 +1,20 @@
+import forge from 'mappersmith'
+import Retry, { RetryMiddlewareOptions } from 'mappersmith/middleware/retry/v2'
+
+const retryConfigs: RetryMiddlewareOptions = {
+  headerRetryCount: 'X-Mappersmith-Retry-Count',
+  headerRetryTime: 'X-Mappersmith-Retry-Time',
+  maxRetryTimeInSecs: 5,
+  initialRetryTimeInSecs: 0.1,
+  factor: 0.2, // randomization factor
+  multiplier: 2, // exponential factor
+  retries: 5, // max retries
+  validateRetry: (response) => response.responseStatus >= 500 // a function that returns true if the request should be retried
+}
+
+const client = forge({
+  middleware: [ Retry(retryConfigs) ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/middleware/retry.spec.ts
+++ b/spec/typescript/middleware/retry.spec.ts
@@ -1,0 +1,9 @@
+import forge from 'mappersmith'
+import Retry from 'mappersmith/middleware/retry'
+
+const client = forge({
+  middleware: [ Retry ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/middleware/timeout.spec.ts
+++ b/spec/typescript/middleware/timeout.spec.ts
@@ -1,0 +1,11 @@
+import forge from 'mappersmith'
+import TimeoutMiddleware from 'mappersmith/middleware/timeout'
+
+const Timeout = TimeoutMiddleware(500)
+
+const client = forge({
+  middleware: [ Timeout ],
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {}
+})

--- a/spec/typescript/test.spec.ts
+++ b/spec/typescript/test.spec.ts
@@ -1,0 +1,27 @@
+import forge from 'mappersmith'
+import {mockClient} from 'mappersmith/test'
+
+const github = forge({
+  clientId: 'github',
+  host: 'https://status.github.com',
+  resources: {
+    Status: {
+      current: { path: '/api/status.json' },
+      messages: { path: '/api/messages.json' },
+      lastMessage: { path: '/api/last-message.json' },
+    },
+  },
+})
+
+const mock = mockClient<typeof github>(github)
+  .resource('Status')
+  .method('current')
+  .with({
+    id: 'abc',
+  })
+  .response({ allUsers: [] })
+  .assertObject()
+
+console.log(mock.mostRecentCall())
+console.log(mock.callsCount())
+console.log(mock.calls())

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true
+  },
+  "include": [
+    "typings",
+    "spec/typescript/*",
+    "spec/typescript/**/*"
+  ]
+}

--- a/typings/gateway/fetch.d.ts
+++ b/typings/gateway/fetch.d.ts
@@ -1,0 +1,6 @@
+declare module 'mappersmith/gateway/fetch' {
+  import {FetchGateway} from 'mappersmith'
+
+  const Fetch: FetchGateway
+  export default Fetch
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,181 @@
+/// <reference path="./middleware/basic-auth.d.ts" />
+/// <reference path="./middleware/csrf.d.ts" />
+/// <reference path="./middleware/duration.d.ts" />
+/// <reference path="./middleware/encode-json.d.ts" />
+/// <reference path="./middleware/global-error-handler.d.ts" />
+/// <reference path="./middleware/log.d.ts" />
+/// <reference path="./middleware/retry.d.ts" />
+/// <reference path="./middleware/timeout.d.ts" />
+/// <reference path="./gateway/fetch.d.ts" />
+/// <reference path="./test.d.ts" />
+
+declare module 'mappersmith' {
+  export interface Headers {
+    readonly [header: string]: string
+  }
+
+  export interface Authorization {
+    readonly username: string
+    readonly password: string
+  }
+
+  export interface Parameters {
+    readonly auth?: Authorization
+    readonly timeout?: number
+    [param: string]: object | string | number | undefined
+  }
+
+  export type Context = object
+
+  export interface RequestParams {
+    readonly params: Parameters
+    readonly headers: Headers
+    readonly body: object | string
+    readonly auth: object
+    readonly timeout: number
+  }
+
+  export interface ResponseParams {
+    readonly status: number
+    readonly rawData: string
+    readonly headers: Headers
+    readonly error: Error
+  }
+
+  export interface Request {
+    params(): Parameters
+    method(): string
+    host(): string
+    path(): string
+    url(): string
+    headers(): Headers
+    header(name: string): string | undefined
+    body(): object | string
+    auth(): object
+    timeout(): number
+    enhance(extras: Partial<RequestParams>): Request
+    isBinary(): boolean
+  }
+
+  export interface Response {
+    readonly responseStatus: number
+    request(): Request
+    status(): number
+    success(): boolean
+    headers(): Headers
+    header(name: string): string | undefined
+    rawData(): string | null
+    data<DataType = object | string>(): DataType
+    isContentTypeJSON(): boolean
+    error(): Error | null
+    enhance(extras: Partial<ResponseParams>): Response
+  }
+
+  export type RequestGetter = () => Promise<Request>
+
+  export type ResponseGetter = () => Promise<Response>
+
+  export type AbortFn =  (error: Error) => void
+
+  export type RenewFn = () => Promise<object>
+
+  export interface MiddlewareDescriptor {
+    // @deprecated: Please use prepareRequest instead
+    request?(request: Request): Promise<Request> | Request
+    prepareRequest?(next: RequestGetter, abort: AbortFn): Promise<Request | void>
+    response?(next: ResponseGetter, renew: RenewFn): Promise<Response | object>
+  }
+
+  export interface MiddlewareParams {
+    readonly resourceName: string
+    readonly resourceMethod: string
+    readonly clientId: string
+    readonly context: Context
+  }
+
+  export type Middleware = (params: MiddlewareParams) => MiddlewareDescriptor
+
+  export type AsyncFunctions<HashType> = {
+    [Key in keyof HashType]: (params?: Parameters) => Promise<Response>
+  }
+
+  export type Client<ResourcesType> = {
+    [ResourceKey in keyof ResourcesType]: AsyncFunctions<ResourcesType[ResourceKey]>
+  }
+
+  export interface Options<ResourcesType> {
+    readonly clientId?: string
+    readonly host?: string
+    readonly middleware?: Middleware[]
+    // @alias middleware
+    readonly middlewares?: Middleware[]
+    readonly resources: ResourcesType
+  }
+
+  export interface Gateway {
+    call(): void
+    dispatchClientError(message: string, error: Error): void
+    dispatchResponse(response: Response): void
+    extends(methods: {[fn: string]: Function}): void
+    options(): object
+    prepareBody(method: string, headers: Headers): string
+    shouldEmulateHTTP(): boolean
+  }
+
+  interface NetworkGateway {
+    delete?(): void
+    get(): void
+    head(): void
+    patch(): void
+    post(): void
+    put(): void
+  }
+
+  export interface FetchGateway extends Gateway, GlobalFetch {}
+
+  export interface HTTPGateway extends Gateway, NetworkGateway {
+    configure(): object
+    createResponse(response: Response, rawData: string): Response
+    onError(error: Error): void
+    onResponse(response: Response, options: object, params: object): void
+    performRequest(method: string): void
+  }
+
+  export interface MockGateway extends Gateway, NetworkGateway {
+    callMock(): Promise<Response>
+  }
+
+  export interface XhrGateway extends Gateway, NetworkGateway {
+    readonly withCredentials: boolean
+    configure(xmlHttpRequest: XMLHttpRequest): void
+    configureBinary(xmlHttpRequest: XMLHttpRequest): void
+    configureCallbacks(xmlHttpRequest: XMLHttpRequest): void
+    configureTimeout(xmlHttpRequest: XMLHttpRequest): void
+    createResponse(xmlHttpRequest: XMLHttpRequest): void
+    createXHR(): XMLHttpRequest
+    performRequest(method: string): void
+    setHeaders(xmlHttpRequest: XMLHttpRequest, headers: Headers): void
+  }
+
+  export interface GatewayConfiguration {
+    Fetch: object
+    HTTP: Partial<HTTPGateway>
+    Mock: object
+    XHR: Partial<XhrGateway>
+  }
+
+  export interface Configuration {
+    fetch: typeof fetch
+    gateway: Gateway
+    gatewayConfigs: GatewayConfiguration
+    maxMiddlewareStackExecutionAllowed: number
+    middleware: Middleware[]
+    Promise: Promise<any>
+  }
+
+  export var configs: Configuration
+
+  export function setContext(context: Context): void
+
+  export default function forge<ResourcesType>(options: Options<ResourcesType>): Client<ResourcesType>
+}

--- a/typings/middleware/basic-auth.d.ts
+++ b/typings/middleware/basic-auth.d.ts
@@ -1,0 +1,5 @@
+declare module 'mappersmith/middleware/basic-auth' {
+  import {Middleware, Authorization} from 'mappersmith'
+
+  export default function BasicAuthMiddleware(authConfig: Authorization): Middleware
+}

--- a/typings/middleware/csrf.d.ts
+++ b/typings/middleware/csrf.d.ts
@@ -1,0 +1,5 @@
+declare module 'mappersmith/middleware/csrf' {
+  import {Middleware} from 'mappersmith'
+
+  export default function CSRF(...headers: string[]): Middleware
+}

--- a/typings/middleware/duration.d.ts
+++ b/typings/middleware/duration.d.ts
@@ -1,0 +1,6 @@
+declare module 'mappersmith/middleware/duration' {
+  import {Middleware} from 'mappersmith'
+
+  const Duration: Middleware
+  export default Duration
+}

--- a/typings/middleware/encode-json.d.ts
+++ b/typings/middleware/encode-json.d.ts
@@ -1,0 +1,6 @@
+declare module 'mappersmith/middleware/encode-json' {
+  import {Middleware} from 'mappersmith'
+
+  const EncodeJson: Middleware
+  export default EncodeJson
+}

--- a/typings/middleware/global-error-handler.d.ts
+++ b/typings/middleware/global-error-handler.d.ts
@@ -1,0 +1,10 @@
+declare module 'mappersmith/middleware/global-error-handler' {
+  import {Middleware, Response} from 'mappersmith'
+
+  const GlobalErrorHandler: Middleware
+
+  export type ErrorHandlerMiddlewareCallback = (response: Response) => boolean
+
+  export function setErrorHandler(fn: ErrorHandlerMiddlewareCallback): void
+  export default GlobalErrorHandler
+}

--- a/typings/middleware/log.d.ts
+++ b/typings/middleware/log.d.ts
@@ -1,0 +1,6 @@
+declare module 'mappersmith/middleware/log' {
+  import {Middleware} from 'mappersmith'
+
+  const Log: Middleware
+  export default Log
+}

--- a/typings/middleware/retry.d.ts
+++ b/typings/middleware/retry.d.ts
@@ -1,0 +1,24 @@
+// @deprecated: Version 1 of retry is deprecated and should not be used anymore
+declare module 'mappersmith/middleware/retry' {
+  import {Middleware} from 'mappersmith'
+
+  const Retry: Middleware
+  export default Retry
+}
+
+declare module 'mappersmith/middleware/retry/v2' {
+  import {Middleware, Response} from 'mappersmith'
+
+  export interface RetryMiddlewareOptions {
+    readonly headerRetryCount: string
+    readonly headerRetryTime: string
+    readonly maxRetryTimeInSecs: number
+    readonly initialRetryTimeInSecs: number
+    readonly factor: number
+    readonly multiplier: number
+    readonly retries: number
+    validateRetry(response: Response): boolean
+  }
+
+  export default function Retry(config: Partial<RetryMiddlewareOptions>): Middleware
+}

--- a/typings/middleware/timeout.d.ts
+++ b/typings/middleware/timeout.d.ts
@@ -1,0 +1,7 @@
+declare module 'mappersmith/middleware/timeout' {
+  import {Middleware} from 'mappersmith'
+
+  export type Milliseconds = number
+
+  export default function Timeout(duration: Milliseconds): Middleware
+}

--- a/typings/test.d.ts
+++ b/typings/test.d.ts
@@ -1,0 +1,27 @@
+declare module 'mappersmith/test' {
+  import {Client, Parameters, Request} from 'mappersmith'
+
+  export interface MockAssert {
+    calls(): Request[]
+    callsCount(): number
+    mostRecentCall(): Request | null
+  }
+
+  export type StatusHandler = (request: Request, mock: MockAssert) => void
+
+  export type ResponseHandler = (request: Request, mock: MockAssert) => void
+
+  export interface MockClient<ResourcesType> {
+    resource(name: keyof ResourcesType): MockClient<ResourcesType>
+    method(name: keyof ResourcesType[keyof ResourcesType]): MockClient<ResourcesType>
+    with(args: Partial<Parameters>): MockClient<ResourcesType>
+    status(responder: StatusHandler | number): MockClient<ResourcesType>
+    response(responder: ResponseHandler | object | string): MockClient<ResourcesType>
+    assertObject(): MockAssert
+    assertObjectAsync(): Promise<MockAssert>
+  }
+
+  export function install(): void
+  export function uninstall(): void
+  export function mockClient<ResourcesType>(client: Client<ResourcesType>): MockClient<ResourcesType>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7266,6 +7266,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"


### PR DESCRIPTION
## Description

This aims to add TypeScript support to mappersmith. Most of the action happens in `typings/index.d.ts` where the main types are defined. The `spec/typescript` folder is to run the `tsc` command against, to test the actual implemented types.

## ToDos

- [x] Local test in a TypeScript environment where mappersmith is used