### PR TITLE
Add `ignoreGlobalMiddleware` to types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -106,6 +106,7 @@ declare module 'mappersmith' {
   export interface Options<ResourcesType> {
     readonly clientId?: string
     readonly host?: string
+    readonly ignoreGlobalMiddleware?: boolean
     readonly middleware?: Middleware[]
     // @alias middleware
     readonly middlewares?: Middleware[]


### PR DESCRIPTION
`ignoreGlobalMiddleware` was missing in the type definition