### PR TITLE
Replace GlobalFetch with WindowOrWorkerGlobalScope

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -133,7 +133,7 @@ declare module 'mappersmith' {
     put(): void
   }
 
-  export interface FetchGateway extends Gateway, GlobalFetch {}
+  export interface FetchGateway extends Gateway, WindowOrWorkerGlobalScope {}
 
   export interface HTTPGateway extends Gateway, NetworkGateway {
     configure(): object


### PR DESCRIPTION
GlobalFetch is deprecated in [Typescript 3.6](https://devblogs.microsoft.com/typescript/announcing-typescript-3-6/). The suggested replacement is WindowOrWorkerGlobalScope.

> DOM Updates
> GlobalFetch is gone. Instead, use WindowOrWorkerGlobalScope

This change has been tested with Typescript `3.5.3` and `3.6.2`.

### Resources
- [Window](https://developer.mozilla.org/en-US/docs/Web/API/Window#Methods_implemented_from_elsewhere)
- [WindowOrWorkerGlobalScope](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope)
- [fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)