### PR TITLE
remove in TypeScript 3.6 removed type GlobalFetch from FetchGateway

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -133,7 +133,7 @@ declare module 'mappersmith' {
     put(): void
   }
 
-  export interface FetchGateway extends Gateway, GlobalFetch {}
+  export interface FetchGateway extends Gateway {}
 
   export interface HTTPGateway extends Gateway, NetworkGateway {
     configure(): object


### PR DESCRIPTION
In TypeScript 3.6 the global type `GlobalFetch` will be renamed, were it would need to be extracted in the following way: `WindowOrWorkerGlobalScope['fetch']`. While checking the interface `FetchGateway` it came up that the GlobalFetch does not need to be extended. So I removed it :) 