### PR TITLE
Fix fetch configs not working

### DIFF
--- a/src/gateway/fetch.js
+++ b/src/gateway/fetch.js
@@ -61,7 +61,7 @@ Fetch.prototype = Gateway.extends({
 
     const headers = assign(customHeaders, this.request.headers())
     const requestMethod = this.shouldEmulateHTTP() ? 'post' : method
-    const init = assign({ method: requestMethod, headers, body }, this.options())
+    const init = assign({ method: requestMethod, headers, body }, this.options().Fetch)
     const timeout = this.request.timeout()
 
     let timer = null


### PR DESCRIPTION
This pull request fixes "configs.gatewayConfigs.Fetch" not working.

According to the example this should now work 
```
configs.gatewayConfigs.Fetch = {
  credentials: 'same-origin'
}
```