### PR TITLE
Allow not sending a config in the Retry middleware

### DIFF
--- a/typings/middleware/retry.d.ts
+++ b/typings/middleware/retry.d.ts
@@ -20,5 +20,5 @@ declare module 'mappersmith/middleware/retry/v2' {
     validateRetry(response: Response): boolean
   }
 
-  export default function Retry(config: Partial<RetryMiddlewareOptions>): Middleware
+  export default function Retry(config?: Partial<RetryMiddlewareOptions>): Middleware
 }


### PR DESCRIPTION
Since the Retry middleware already assigns the default config when it's created with no parameters, that should be reflected in the Typescript definition files.