### PR TITLE
Add support for optional path params (dynamic segments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ const client = forge({
 
       // {group} is also a dynamic segment but it has default value "general"
       byGroup: { path: '/users/groups/{group}', params: { group: 'general' } }
+
+      // {market?} is an optional dynamic segment. If called without a value
+      // for the "market" parameter, {market?} will be removed from the path
+      // including any prefixing "/".
+      // This example: '/{market?}/users' => '/users'
+      count: { path: '/{market?}/users' } }
     },
     Blog: {
       // The HTTP method can be configured through the `method` key, and a default

--- a/spec/browser/request.spec.js
+++ b/spec/browser/request.spec.js
@@ -131,6 +131,13 @@ describe('Request', () => {
       expect(path).toEqual('/api/example/1.json?title=test')
     })
 
+    it('interpolates paths with optional dynamic sections', () => {
+      methodDescriptor.path = '/api/example/{id?}.json'
+      methodDescriptor.params = { 'id': 1, title: 'test' }
+      const path = new Request(methodDescriptor).path()
+      expect(path).toEqual('/api/example/1.json?title=test')
+    })
+
     it('encodes params in dynamic sections', () => {
       methodDescriptor.path = '/api/example.json?email={email}'
       methodDescriptor.params = { email: 'email+test@example.com' }
@@ -147,6 +154,13 @@ describe('Request', () => {
     })
 
     describe('when dynamic section is not provided', () => {
+      it('removes optional dynamic sections', () => {
+        methodDescriptor.path = '/api/{optional?}/example.json'
+        methodDescriptor.params = {}
+        const path = new Request(methodDescriptor).path()
+        expect(path).toEqual('/api/example.json')
+      })
+
       it('raises an exception', () => {
         methodDescriptor.path = '/api/example/{id}.json'
         expect(() => new Request(methodDescriptor).path())

--- a/spec/browser/request.spec.js
+++ b/spec/browser/request.spec.js
@@ -124,28 +124,28 @@ describe('Request', () => {
       expect(path).toEqual('/api/example.json?user_email=email%2Btest%40example.com')
     })
 
-    it('interpolates paths with dynamic sections', () => {
+    it('interpolates paths with dynamic segments', () => {
       methodDescriptor.path = '/api/example/{id}.json'
       methodDescriptor.params = { id: 1, title: 'test' }
       const path = new Request(methodDescriptor).path()
       expect(path).toEqual('/api/example/1.json?title=test')
     })
 
-    it('interpolates paths with optional dynamic sections', () => {
+    it('interpolates paths with optional dynamic segments', () => {
       methodDescriptor.path = '/api/example/{id?}.json'
       methodDescriptor.params = { 'id': 1, title: 'test' }
       const path = new Request(methodDescriptor).path()
       expect(path).toEqual('/api/example/1.json?title=test')
     })
 
-    it('encodes params in dynamic sections', () => {
+    it('encodes params in dynamic segments', () => {
       methodDescriptor.path = '/api/example.json?email={email}'
       methodDescriptor.params = { email: 'email+test@example.com' }
       const path = new Request(methodDescriptor).path()
       expect(path).toEqual('/api/example.json?email=email%2Btest%40example.com')
     })
 
-    it('does not apply queryParamAlias to interpolated dynamic sections', () => {
+    it('does not apply queryParamAlias to interpolated dynamic segments', () => {
       methodDescriptor.path = '/api/example/{userId}.json'
       methodDescriptor.params = { userId: 1 }
       methodDescriptor.queryParamAlias = { userId: 'user_id' }
@@ -153,9 +153,9 @@ describe('Request', () => {
       expect(path).toEqual('/api/example/1.json')
     })
 
-    describe('when dynamic section is not provided', () => {
-      it('removes optional dynamic sections', () => {
-        methodDescriptor.path = '/api/{optional?}/example.json'
+    describe('when dynamic segment is not provided', () => {
+      it('removes optional dynamic segments', () => {
+        methodDescriptor.path = '{prefix?}/api/{optional?}/example.json'
         methodDescriptor.params = {}
         const path = new Request(methodDescriptor).path()
         expect(path).toEqual('/api/example.json')

--- a/src/request.js
+++ b/src/request.js
@@ -1,7 +1,7 @@
 import { toQueryString, lowerCaseObjectKeys, assign } from './utils'
 
 const REGEXP_DYNAMIC_SEGMENT = /{([^}]+)}/
-const REGEXP_OPTIONAL_DYNAMIC_SEGMENT = /\/?{[^}]+\?}/
+const REGEXP_OPTIONAL_DYNAMIC_SEGMENT = /\/?{[^}]+\?}/g
 const REGEXP_TRAILING_SLASH = /\/$/
 
 /**

--- a/src/request.js
+++ b/src/request.js
@@ -1,6 +1,7 @@
 import { toQueryString, lowerCaseObjectKeys, assign } from './utils'
 
 const REGEXP_DYNAMIC_SEGMENT = /{([^}]+)}/
+const REGEXP_OPTIONAL_DYNAMIC_SEGMENT = /\/?{[^}]+\?}/
 const REGEXP_TRAILING_SLASH = /\/$/
 
 /**
@@ -86,13 +87,15 @@ Request.prototype = {
     const params = this.params()
     Object.keys(params).forEach((key) => {
       const value = params[key]
-      const pattern = `{${key}}`
+      const pattern = new RegExp(`{${key}\\??}`)
 
-      if (new RegExp(pattern).test(path)) {
-        path = path.replace(`{${key}}`, encodeURIComponent(value))
+      if (pattern.test(path)) {
+        path = path.replace(pattern, encodeURIComponent(value))
         delete params[key]
       }
     })
+
+    path = path.replace(REGEXP_OPTIONAL_DYNAMIC_SEGMENT, '')
 
     const missingDynamicSegmentMatch = path.match(REGEXP_DYNAMIC_SEGMENT)
     if (missingDynamicSegmentMatch) {


### PR DESCRIPTION
Support paths params like `/api/{market?}/users`, that would result in `/api/users` if the `market` parameter is missing in request.