### PR TITLE
Ignore null or undefined values for dynamic segments

### DIFF
--- a/spec/browser/request.spec.js
+++ b/spec/browser/request.spec.js
@@ -138,6 +138,13 @@ describe('Request', () => {
       expect(path).toEqual('/api/example/1.json?title=test')
     })
 
+    it('interpolates paths with optional dynamic segments with falsy value', () => {
+      methodDescriptor.path = '/api/{boolean}/example/{id?}.json'
+      methodDescriptor.params = { 'id': 0, boolean: false, title: 'test' }
+      const path = new Request(methodDescriptor).path()
+      expect(path).toEqual('/api/false/example/0.json?title=test')
+    })
+
     it('interpolates paths with multiple occurrence of same dynamic segment', () => {
       methodDescriptor.path = '/api/{path?}/{path}/{id}.json'
       methodDescriptor.params = { id: 1, path: 'test', title: 'value' }
@@ -166,6 +173,13 @@ describe('Request', () => {
         methodDescriptor.params = {}
         const path = new Request(methodDescriptor).path()
         expect(path).toEqual('/api/example.json')
+      })
+
+      it('removes optional dynamic segments with null or undefined value', () => {
+        methodDescriptor.path = '/api/{null?}/path/{undefined?}/example.json'
+        methodDescriptor.params = { 'undefined': undefined, 'null': null }
+        const path = new Request(methodDescriptor).path()
+        expect(path).toEqual('/api/path/example.json')
       })
 
       it('raises an exception', () => {

--- a/src/request.js
+++ b/src/request.js
@@ -89,11 +89,15 @@ Request.prototype = {
     // RegExp with 'g'-flag is stateful, therefore defining it locally
     const regexp = new RegExp(REGEXP_DYNAMIC_SEGMENT, 'g')
 
+    let dynamicSegmentKeys = []
     let match
     while ((match = regexp.exec(path)) !== null) {
-      const key = match[1]
+      dynamicSegmentKeys.push(match[1])
+    }
+
+    for (let key of dynamicSegmentKeys) {
       const pattern = new RegExp(`{${key}\\??}`, 'g')
-      if (key in params) {
+      if (params[key] != null) {
         path = path.replace(pattern, encodeURIComponent(params[key]))
         delete params[key]
       }


### PR DESCRIPTION
Thoughts:
- Should we **only** ignore `null` and `undefined` for *optional* dynamic segments? In that way we can keep the current behaviour for mandatory dynamic segments, which is to replace it with `undefined` or `null`.
 