### PR TITLE
Fix so only param matchers are changed for mocks

### DIFF
--- a/spec/browser/test/mock-resource.spec.js
+++ b/spec/browser/test/mock-resource.spec.js
@@ -363,7 +363,7 @@ describe('Test lib / mock resources', () => {
       })
   })
 
-  describe.only('when using param matchers', () => {
+  describe('when using param matchers', () => {
     it('evaluates only params with matcher function, let others be', (done) => {
       mockClient(client)
         .resource('User')

--- a/spec/browser/test/mock-resource.spec.js
+++ b/spec/browser/test/mock-resource.spec.js
@@ -363,6 +363,23 @@ describe('Test lib / mock resources', () => {
       })
   })
 
+  describe.only('when using param matchers', () => {
+    it('evaluates only params with matcher function, let others be', (done) => {
+      mockClient(client)
+        .resource('User')
+        .method('all')
+        .with({ param1: 'NOT_MATCHING', param2: () => true })
+
+      client.User.all({ param1: 'THIS_SHOULD_NOT_MATCH', param2: 'anything' })
+        .then(() => {
+          done.fail(`should not find match`)
+        })
+        .catch(() => {
+          done()
+        })
+    })
+  })
+
   describe('when client is using middlewares', () => {
     let params
 


### PR DESCRIPTION
My brain hurts after this debug session 🤕😂 

This PR fixes a bug (or at least I think it is a bug) that happens when using mocks with param-matcher functions. The bug is that if a mock contains at least one param-matcher function, then all params provided in `.with()` will be replaced in the "evaluation" of the param-matchers. 

A bit hard to explain (I'm a bad writer), but I think the test in this PR shows the bug quite well.