### PR TITLE
Add json-encode middleware export CONTENT_TYPE_JSON to type definition

### DIFF
--- a/typings/middleware/encode-json.d.ts
+++ b/typings/middleware/encode-json.d.ts
@@ -2,5 +2,7 @@ declare module 'mappersmith/middleware/encode-json' {
   import {Middleware} from 'mappersmith'
 
   const EncodeJson: Middleware
+
+  export var CONTENT_TYPE_JSON: string
   export default EncodeJson
 }


### PR DESCRIPTION
The exported constant `CONTENT_TYPE_JSON` (from middleware/json-encode) was missing from the type declaration. 