### PR TITLE
Add support for enhancing the path property

### DIFF
--- a/spec/browser/request.spec.js
+++ b/spec/browser/request.spec.js
@@ -148,8 +148,8 @@ describe('Request', () => {
     })
 
     it('interpolates paths with multiple occurrence of same dynamic segment', () => {
-      methodDescriptor.path = '/api/{path?}/{path}/{id}.json'
-      methodDescriptor.params = { id: 1, path: 'test', title: 'value' }
+      methodDescriptor.path = '/api/{prefix?}/{prefix}/{id}.json'
+      methodDescriptor.params = { id: 1, prefix: 'test', title: 'value' }
       const path = new Request(methodDescriptor).path()
       expect(path).toEqual('/api/test/test/1.json?title=value')
     })
@@ -365,6 +365,14 @@ describe('Request', () => {
       const enhancedRequest = request.enhance({ timeout: 2000 })
       expect(enhancedRequest).not.toEqual(request)
       expect(enhancedRequest.timeout()).toEqual(2000)
+    })
+
+    it('creates a new request based on the current request replacing the path', () => {
+      methodDescriptor.path = 'api/example-1.json'
+      const request = new Request(methodDescriptor)
+      const enhancedRequest = request.enhance({ path: 'api/example-2.json' })
+      expect(enhancedRequest).not.toEqual(request)
+      expect(enhancedRequest.path()).toEqual('/api/example-2.json')
     })
 
     it('does not remove the previously assigned "body"', () => {

--- a/src/method-descriptor.js
+++ b/src/method-descriptor.js
@@ -13,6 +13,7 @@
  *   @param {String} obj.authAttr - auth attribute name. Default: 'auth'
  *   @param {Number} obj.timeoutAttr - timeout attribute name. Default: 'timeout'
  *   @param {String} obj.hostAttr - host attribute name. Default: 'host'
+ *   @param {String} obj.pathAttr - path attribute name. Default: 'path'
  */
 export default function MethodDescriptor (obj) {
   this.host = obj.host
@@ -29,6 +30,7 @@ export default function MethodDescriptor (obj) {
   this.authAttr = obj.authAttr || 'auth'
   this.timeoutAttr = obj.timeoutAttr || 'timeout'
   this.hostAttr = obj.hostAttr || 'host'
+  this.pathAttr = obj.pathAttr || 'path'
 
   const resourceMiddleware = obj.middleware || obj.middlewares || []
   this.middleware = resourceMiddleware

--- a/src/request.js
+++ b/src/request.js
@@ -30,7 +30,8 @@ Request.prototype = {
         key !== this.methodDescriptor.bodyAttr &&
         key !== this.methodDescriptor.authAttr &&
         key !== this.methodDescriptor.timeoutAttr &&
-        key !== this.methodDescriptor.hostAttr
+        key !== this.methodDescriptor.hostAttr &&
+        key !== this.methodDescriptor.pathAttr
     )
 
     return Object
@@ -81,12 +82,10 @@ Request.prototype = {
   path () {
     const params = this.params()
 
-    let path
+    let path = this.requestParams[this.methodDescriptor.pathAttr] || this.methodDescriptor.path
 
-    if (typeof this.methodDescriptor.path === 'function') {
-      path = this.methodDescriptor.path(params)
-    } else {
-      path = this.methodDescriptor.path
+    if (typeof path === 'function') {
+      path = path(params)
     }
 
     if (path[0] !== '/') {
@@ -191,7 +190,8 @@ Request.prototype = {
    *   @param {String|Object} extras.body - it will replace the current body
    *   @param {Object} extras.auth - it will replace the current auth
    *   @param {Number} extras.timeout - it will replace the current timeout
-   *   @param {String} extras.host - it will replace the current timeout
+   *   @param {String} extras.host - it will replace the current host
+   *   @param {String} extras.path - it will replace the current path
    */
   enhance (extras) {
     const headerKey = this.methodDescriptor.headersAttr
@@ -199,6 +199,7 @@ Request.prototype = {
     const authKey = this.methodDescriptor.authAttr
     const timeoutKey = this.methodDescriptor.timeoutAttr
     const hostKey = this.methodDescriptor.hostAttr
+    const pathKey = this.methodDescriptor.pathAttr
     const requestParams = assign({}, this.requestParams, extras.params)
 
     requestParams[headerKey] = assign({}, this.requestParams[headerKey], extras.headers)
@@ -206,6 +207,7 @@ Request.prototype = {
     extras.auth && (requestParams[authKey] = extras.auth)
     extras.timeout && (requestParams[timeoutKey] = extras.timeout)
     extras.host && (requestParams[hostKey] = extras.host)
+    extras.path && (requestParams[pathKey] = extras.path)
 
     return new Request(this.methodDescriptor, requestParams)
   },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -35,6 +35,7 @@ declare module 'mappersmith' {
     readonly auth: object
     readonly timeout: number
     readonly host: string
+    readonly path: string
   }
 
   export interface ResponseParams {


### PR DESCRIPTION
This PR adds support for overriding the path in a middleware. I regard this a breaking change as it adds a new "reserved" property name that needs to be circumvented with `pathAttr` if it conflicts with regular request params. 