### PR TITLE
Update types to allow passing gatewayConfigs to forge options

### DIFF
--- a/spec/typescript/basic.spec.ts
+++ b/spec/typescript/basic.spec.ts
@@ -3,6 +3,15 @@ import forge from 'mappersmith'
 const github = forge({
   clientId: 'github',
   host: 'https://status.github.com',
+  gatewayConfigs: {
+    HTTP: {
+      configure() {
+        return {
+          port: "1234"
+        }
+      }
+    }
+  },
   resources: {
     Status: {
       current: { path: '/api/status.json' },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -110,6 +110,7 @@ declare module 'mappersmith' {
     readonly host?: string
     readonly ignoreGlobalMiddleware?: boolean
     readonly middleware?: Middleware[]
+    readonly gatewayConfigs?: Partial<GatewayConfiguration>
     // @alias middleware
     readonly middlewares?: Middleware[]
     readonly resources: ResourcesType


### PR DESCRIPTION
In https://github.com/kafkajs/confluent-schema-registry/pull/108 we want to configure the gateway for one specific client, instead of modifying it globally. This is possible in JS, but the Typescript types were missing the `gatewayConfigs` property on the `Options` passed to forge.