### PR TITLE
feat: allow specifying methods for requests to be retried

### DIFF
--- a/spec/typescript/middleware/retry-v2.spec.ts
+++ b/spec/typescript/middleware/retry-v2.spec.ts
@@ -2,6 +2,7 @@ import forge from 'mappersmith'
 import Retry, { RetryMiddlewareOptions } from 'mappersmith/middleware/retry/v2'
 
 const retryConfigs: RetryMiddlewareOptions = {
+  allowedMethods: ['GET'], // methods allowed to be retried
   headerRetryCount: 'X-Mappersmith-Retry-Count',
   headerRetryTime: 'X-Mappersmith-Retry-Time',
   maxRetryTimeInSecs: 5,

--- a/src/middleware/retry/v2/index.js
+++ b/src/middleware/retry/v2/index.js
@@ -3,6 +3,7 @@ import { assign } from '../../../utils'
 import Response from '../../../response'
 
 export const defaultRetryConfigs = {
+  allowedMethods: ['GET'], // methods allowed to be retried
   headerRetryCount: 'X-Mappersmith-Retry-Count',
   headerRetryTime: 'X-Mappersmith-Retry-Time',
   maxRetryTimeInSecs: 5,
@@ -36,16 +37,16 @@ export const defaultRetryConfigs = {
  *   @param {Number} retryConfigs.retries (default: 5) - max retries
  */
 export default (customConfigs = {}) => function RetryMiddleware () {
+  const retryConfigs = assign({}, defaultRetryConfigs, customConfigs)
+
   return {
     request (request) {
-      this.enableRetry = (request.method() === 'get')
+      this.enableRetry = retryConfigs.allowedMethods.includes(request.method().toUpperCase())
       this.inboundRequest = request
       return request
     },
 
     response (next) {
-      const retryConfigs = assign({}, defaultRetryConfigs, customConfigs)
-
       if (!this.enableRetry) {
         return next()
       }

--- a/typings/middleware/retry.d.ts
+++ b/typings/middleware/retry.d.ts
@@ -6,7 +6,7 @@ declare module 'mappersmith/middleware/retry' {
   export default Retry
 }
 
-type HttpMethod =
+type httpMethod =
   | "GET"
   | "HEAD"
   | "POST"
@@ -21,7 +21,7 @@ declare module 'mappersmith/middleware/retry/v2' {
   import {Middleware, Response} from 'mappersmith'
 
   export interface RetryMiddlewareOptions {
-    readonly allowedMethods: HttpMethod[]
+    readonly allowedMethods: httpMethod[]
     readonly headerRetryCount: string
     readonly headerRetryTime: string
     readonly maxRetryTimeInSecs: number

--- a/typings/middleware/retry.d.ts
+++ b/typings/middleware/retry.d.ts
@@ -6,10 +6,22 @@ declare module 'mappersmith/middleware/retry' {
   export default Retry
 }
 
+type HttpMethod =
+  | "GET"
+  | "HEAD"
+  | "POST"
+  | "PUT"
+  | "DELETE"
+  | "CONNECT"
+  | "OPTIONS"
+  | "TRACE"
+  | "PATCH"
+
 declare module 'mappersmith/middleware/retry/v2' {
   import {Middleware, Response} from 'mappersmith'
 
   export interface RetryMiddlewareOptions {
+    readonly allowedMethods: HttpMethod[]
     readonly headerRetryCount: string
     readonly headerRetryTime: string
     readonly maxRetryTimeInSecs: number


### PR DESCRIPTION
Because currently the Retry middleware only support GET requests. This commit adds the ability to specify custom allowed methods for requests to be retried.