### PR TITLE
Expands the Json content type regexp to accommodate more Json content types

### DIFF
--- a/spec/browser/response.spec.js
+++ b/spec/browser/response.spec.js
@@ -114,9 +114,14 @@ describe('Response', () => {
     })
 
     describe('when responseData is JSON', () => {
-      it('returns the parsed object', () => {
+      it.each([
+        ['application/json;charset=utf-8'],
+        ['application/ld+json;charset=utf-8'],
+        ['application/problem+json;charset=utf-8'],
+        ['application/vnd.spring-boot.actuator.v3+json;charset=utf-8']
+      ])('returns the parsed object given content type %s', (contentType) => {
         responseData = JSON.stringify({ nice: 'json' })
-        responseHeaders = { 'Content-Type': 'application/json;charset=utf-8' }
+        responseHeaders = { 'Content-Type': contentType }
         expect(createResponse().data()).toEqual({ nice: 'json' })
       })
 

--- a/spec/browser/response.spec.js
+++ b/spec/browser/response.spec.js
@@ -125,6 +125,18 @@ describe('Response', () => {
         expect(createResponse().data()).toEqual({ nice: 'json' })
       })
 
+      describe('when content type is not json', () => {
+        it.each([
+          ['application/pdf;charset=utf-8'],
+          ['text/html;charset=utf-8'],
+          ['application/vnd.openxmlformats-officedocument.stringwithjsoninit.presentation;charset=utf-8']
+        ])('returns rawData given content type %s', (contentType) => {
+          responseData = JSON.stringify({ nice: 'json' })
+          responseHeaders = { 'Content-Type': contentType }
+          expect(createResponse().data()).toEqual(responseData)
+        })
+      })
+
       describe('and the payload is a invalid JSON', () => {
         it('returns rawData', () => {
           responseData = 'invalid{json}'

--- a/src/response.js
+++ b/src/response.js
@@ -1,6 +1,6 @@
 import { lowerCaseObjectKeys, assign } from './utils'
 
-const REGEXP_CONTENT_TYPE_JSON = /^application\/.*json/
+const REGEXP_CONTENT_TYPE_JSON = /^application\/(json|.*\+json)/
 
 /**
  * @typedef Response

--- a/src/response.js
+++ b/src/response.js
@@ -1,6 +1,6 @@
 import { lowerCaseObjectKeys, assign } from './utils'
 
-const REGEXP_CONTENT_TYPE_JSON = /^application\/json/
+const REGEXP_CONTENT_TYPE_JSON = /^application\/.*json/
 
 /**
  * @typedef Response


### PR DESCRIPTION
Expands the REGEXP_CONTENT_TYPE_JSON regex to recognise more Json content type flavours.
Fixes https://github.com/tulios/mappersmith/issues/223 