### PR TITLE
Prevents pushing undefined values into Response errors stack on enhance

### DIFF
--- a/spec/browser/response.spec.js
+++ b/spec/browser/response.spec.js
@@ -192,6 +192,14 @@ describe('Response', () => {
       expect(enhancedResponse.errors).toEqual([originalError, newError])
     })
 
+    it('creates a new response without adding undefined errors to the stack', () => {
+      const originalError = new Error('original error')
+      const response = createResponse([originalError])
+      const enhancedResponse = response.enhance({})
+
+      expect(enhancedResponse.error()).toEqual(originalError)
+    })
+
     it('preserves timeElapsed', () => {
       const response = createResponse()
       response.timeElapsed = 123

--- a/spec/browser/response.spec.js
+++ b/spec/browser/response.spec.js
@@ -204,7 +204,7 @@ describe('Response', () => {
       const response = createResponse()
       response.timeElapsed = 123
       const enhancedResponse = response.enhance({})
-      expect(enhancedResponse).not.toEqual(response)
+
       expect(enhancedResponse.timeElapsed).toEqual(123)
     })
   })

--- a/src/response.js
+++ b/src/response.js
@@ -134,7 +134,7 @@ Response.prototype = {
       extras.status || this.status(),
       extras.rawData || this.rawData(),
       assign({}, this.headers(), extras.headers),
-      [...this.errors, extras.error]
+      extras.error ? [...this.errors, extras.error] : [...this.errors]
     )
     enhancedResponse.timeElapsed = this.timeElapsed
 


### PR DESCRIPTION
When enhancing responses, if the enhancement does not include error, it is not pushed into the errors stack
Fixes https://github.com/tulios/mappersmith/issues/230