### PR TITLE
Add missing "triple-slash directive" for new typings file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 Fixed:
-  - Fix missing retry-v2 typings in index.d.ts (#260)
+  - Fix missing retry-v2 typings in index.d.ts (#261)
 
 ## 2.36.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+Fixed:
+  - Fix missing retry-v2 typings in index.d.ts (#260)
+
 ## 2.36.1
 
 Fixed:

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,6 +6,7 @@
 /// <reference path="./middleware/global-error-handler.d.ts" />
 /// <reference path="./middleware/log.d.ts" />
 /// <reference path="./middleware/retry.d.ts" />
+/// <reference path="./middleware/retry-v2.d.ts" />
 /// <reference path="./middleware/timeout.d.ts" />
 /// <reference path="./gateway/fetch.d.ts" />
 /// <reference path="./test.d.ts" />


### PR DESCRIPTION
Recently (22f6a16c7329bb51341ffd09b0997a34b629fbb0) the v2 retry middleware was moved out of the primary `retry.d.ts` file into its own.  It appears that this new file needs to be added to the list of triple-slash directives that cause the typescript compiler to include various files that are not explicitly imported.

Without this, I get a compiler error on a module that indirectly (via `@kafkajs/confluent-schema-registry`) uses mappersmith:

```
Could not find a declaration file for module 'mappersmith/middleware/retry/v2'.  '/path/to/my/module/node_modules/mappersmith/middleware/retry/v2/index.js' implicitly has an 'any' type.
If the 'mappersmith' package actually exposes this module, try adding a new declaration (.d.ts) file containing `declare module 'mappersmith/middleware/retry/v2';`ts(7016)
```
