### PR TITLE
Make Response class accept a generic of it's returned data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,26 @@
 # Changelog
 
+## Unreleased
+
+Added:
+  - Make Response accept a generic type that specifies the form of the data returned (#265)
+
 ## 2.36.3
 
 Fixed:
   - Fix missing retry-v2 typings in index.d.ts (#261)
+
+Refactored:
+  - Migrated `ClientBuilder` to typescript
 
 ## 2.36.1
 
 Fixed:
   - Fix broken typings in index.d.ts (#257)
 
-Added
+## 2.36.0
+
+Added:
   - Add option `parameterEncoder` which can optionally be used to override the encoding function for request params. Default is `encodeURIComponent` (backwards compatible change).
 
 Fixed:
@@ -18,6 +28,7 @@ Fixed:
   - Fix `Request.pathTemplate` to return result of the function instead of the function itself
 
 Refactored:
+  - Migrated `Manifest` to typescript
   - Migrated `MethodDescriptor` to typescript
   - Migrated `Request` to typescript
   - Migrated `Response` to typescript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,50 +3,51 @@
 ## Unreleased
 
 Added:
-  - Make Response accept a generic type that specifies the form of the data returned (#265)
+  - Make Response accept a generic type that specifies the form of the data returned #265
+  - Add `responseFactory` and `requestFactory` helpers to `mappersmith/test` #265
 
 ## 2.36.3
 
 Fixed:
-  - Fix missing retry-v2 typings in index.d.ts (#261)
+  - Fix missing retry-v2 typings in index.d.ts #261
 
 Refactored:
-  - Migrated `ClientBuilder` to typescript
+  - Migrated `ClientBuilder` to typescript #259
 
 ## 2.36.1
 
 Fixed:
-  - Fix broken typings in index.d.ts (#257)
+  - Fix broken typings in index.d.ts #257
 
 ## 2.36.0
 
 Added:
-  - Add option `parameterEncoder` which can optionally be used to override the encoding function for request params. Default is `encodeURIComponent` (backwards compatible change).
+  - Add option `parameterEncoder` which can optionally be used to override the encoding function for request params. Default is `encodeURIComponent` #251
 
 Fixed:
-  - Fix `x-started-at` header getting set to new `Date.now()` during testing and failing header match
-  - Fix `Request.pathTemplate` to return result of the function instead of the function itself
+  - Fix `x-started-at` header getting set to new `Date.now()` during testing and failing header match #248
+  - Fix `Request.pathTemplate` to return result of the function instead of the function itself #249
 
 Refactored:
-  - Migrated `Manifest` to typescript
-  - Migrated `MethodDescriptor` to typescript
-  - Migrated `Request` to typescript
-  - Migrated `Response` to typescript
+  - Migrated `Manifest` to typescript #254
+  - Migrated `MethodDescriptor` to typescript #245
+  - Migrated `Request` to typescript #245
+  - Migrated `Response` to typescript #249
 
 ## 2.35.0
 
 Fixed:
-  - Respect `allowResourceHostOverride` configuration in middlewares (#240)
-  - A successful middleware should no longer overwriting a previous middleware's `error` (#230)
+  - Respect `allowResourceHostOverride` configuration in middlewares #240
+  - A successful middleware should no longer overwriting a previous middleware's `error` #230
 
 Added:
-  - `mappersmith`: `Request.pathTemplate` - Returns the template path, without params, before interpolation (#194)
-  - `mappersmith/test`: `unusedMocks` - get count of unused mocks (#227)
-  - The `+json` family of MIME types are parsed as json (#223)
-  - Add headers to mock matching strategy (#168)
+  - `mappersmith`: `Request.pathTemplate` - Returns the template path, without params, before interpolation #194
+  - `mappersmith/test`: `unusedMocks` - get count of unused mocks #227
+  - The `+json` family of MIME types are parsed as json #223
+  - Add headers to mock matching strategy #168
 
 Deprecated:
-  - `mappersmith`: `setContext` - this is not safe for concurrent use (#239)
+  - `mappersmith`: `setContext` - this is not safe for concurrent use #239
 
 ## 2.34.0
 

--- a/spec/typescript/middleware.spec.ts
+++ b/spec/typescript/middleware.spec.ts
@@ -1,4 +1,5 @@
 import forge, { Middleware, MiddlewareParams } from 'mappersmith'
+import { responseFactory } from 'mappersmith/test'
 
 const MyMiddleware: Middleware = () => ({
   prepareRequest(next) {
@@ -61,3 +62,23 @@ const github = forge({
 github.Status.lastMessage().then((response) => {
   console.log(`status: ${response.data()}`)
 })
+
+const myMiddleware = MyMiddleware({
+  clientId: 'github',
+  resourceName: 'Status',
+  resourceMethod: 'current',
+  context: {},
+})
+
+const renewFn = async () => responseFactory()
+
+export const test = async () => {
+  if (myMiddleware.response) {
+    const originalResponse = responseFactory({ data: { a: 1 } })
+    const originalData = originalResponse.data()
+    const response = await myMiddleware.response(async () => originalResponse, renewFn)
+    const data = response.data()
+    // Right now these are different types
+    console.log({ originalData, data })
+  }
+}

--- a/spec/typescript/response.spec.ts
+++ b/spec/typescript/response.spec.ts
@@ -1,0 +1,56 @@
+import forge, { Response } from 'mappersmith'
+
+type User = {
+  name: string
+  id: string
+}
+type GraphQLResponse<T> = Response<{
+  // eslint-disable-next-line camelcase
+  errors?: { message: string; error_type: string; description: string }[]
+  data: T
+}>
+export interface TestResponseClient {
+  User: {
+    get: (params: { userId: string }) => Promise<Response<User>>
+    list: () => Promise<Response<User[]>>
+    update: (params: { query: string }) => Promise<GraphQLResponse<{ user: User }>>
+  }
+}
+
+const testResponseClient: TestResponseClient = forge({
+  clientId: 'testResponseClient',
+  host: 'http://example.com',
+  resources: {
+    User: {
+      get: { path: '/api/users/{userId}' },
+      list: { path: '/api/users' },
+      update: { method: 'post', path: '/graphql' },
+    },
+  },
+})
+
+testResponseClient.User.get({ userId: '10' }).then((response) => {
+  const user = response.data()
+  const status = response.status()
+  console.log(`[${status}] user id: ${user.id} has name ${user.name}`)
+})
+
+const query = `
+  query UpdateUserTest($userId: string!, $name: string) { 
+    updateUser(userId: $userId, name: $name) { 
+      user: {
+        id
+        name
+      }
+    }
+  }
+`
+
+testResponseClient.User.update({ query }).then((rawResponse) => {
+  const response = rawResponse.data()
+  if (response.errors) {
+    throw new Error(`Operation errors: ${response.errors}`)
+  }
+  const { user } = response.data
+  console.log(`[${rawResponse.status()}] user id: ${user.id} updated name to ${user.name}`)
+})

--- a/src/client-builder.spec.ts
+++ b/src/client-builder.spec.ts
@@ -1,6 +1,6 @@
 import { ClientBuilder, GatewayConstructor } from './client-builder'
 import { Manifest, GlobalConfigs } from './manifest'
-import { Gateway } from './gateway/types'
+import { Gateway, GatewayConfiguration } from './gateway/types'
 import Request from './request'
 import { getManifest, getManifestWithResourceConf } from '../spec/ts-helper'
 
@@ -23,7 +23,7 @@ describe('ClientBuilder', () => {
       gateway: null,
       gatewayConfigs: {
         Fetch: { config: 'configs' },
-      },
+      } as GatewayConfiguration,
     }
   })
 
@@ -74,7 +74,7 @@ describe('ClientBuilder', () => {
       gateway: null,
       gatewayConfigs: {
         Fetch: { config: 'configs' },
-      },
+      } as GatewayConfiguration,
     }
 
     GatewayClassFactory = () => gatewayClass

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -39,14 +39,14 @@ export interface NetworkGateway {
 
 export interface XhrGateway extends Gateway, NetworkGateway {
   readonly withCredentials: boolean
-  configure: ((xmlHttpRequest: XMLHttpRequest) => void) | null
-  configureBinary?: (xmlHttpRequest: XMLHttpRequest) => void
-  configureCallbacks?: (xmlHttpRequest: XMLHttpRequest) => void
-  configureTimeout?: (xmlHttpRequest: XMLHttpRequest) => void
-  createResponse?: (xmlHttpRequest: XMLHttpRequest) => void
-  setHeaders?: (xmlHttpRequest: XMLHttpRequest, headers: Headers) => void
-  createXHR?(): XMLHttpRequest
-  performRequest?(method: string): void
+  configure?: ((xmlHttpRequest: XMLHttpRequest) => void) | null
+  configureBinary(xmlHttpRequest: XMLHttpRequest): void
+  configureCallbacks(xmlHttpRequest: XMLHttpRequest): void
+  configureTimeout(xmlHttpRequest: XMLHttpRequest): void
+  createResponse(xmlHttpRequest: XMLHttpRequest): void
+  createXHR(): XMLHttpRequest
+  performRequest(method: string): void
+  setHeaders(xmlHttpRequest: XMLHttpRequest, headers: Headers): void
 }
 
 export interface GatewayConfiguration {

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -39,14 +39,14 @@ export interface NetworkGateway {
 
 export interface XhrGateway extends Gateway, NetworkGateway {
   readonly withCredentials: boolean
-  configure?: ((xmlHttpRequest: XMLHttpRequest) => void) | null
-  configureBinary(xmlHttpRequest: XMLHttpRequest): void
-  configureCallbacks(xmlHttpRequest: XMLHttpRequest): void
-  configureTimeout(xmlHttpRequest: XMLHttpRequest): void
-  createResponse(xmlHttpRequest: XMLHttpRequest): void
-  createXHR(): XMLHttpRequest
-  performRequest(method: string): void
-  setHeaders(xmlHttpRequest: XMLHttpRequest, headers: Headers): void
+  configure: ((xmlHttpRequest: XMLHttpRequest) => void) | null
+  configureBinary?: (xmlHttpRequest: XMLHttpRequest) => void
+  configureCallbacks?: (xmlHttpRequest: XMLHttpRequest) => void
+  configureTimeout?: (xmlHttpRequest: XMLHttpRequest) => void
+  createResponse?: (xmlHttpRequest: XMLHttpRequest) => void
+  setHeaders?: (xmlHttpRequest: XMLHttpRequest, headers: Headers) => void
+  createXHR?(): XMLHttpRequest
+  performRequest?(method: string): void
 }
 
 export interface GatewayConfiguration {
@@ -54,6 +54,6 @@ export interface GatewayConfiguration {
   HTTP: HTTPGatewayConfiguration
   Mock?: object
   XHR: Partial<XhrGateway>
-  enableHTTP408OnTimeouts?: boolean
-  emulateHTTP?: boolean
+  enableHTTP408OnTimeouts: boolean
+  emulateHTTP: boolean
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -10,7 +10,7 @@ export interface GlobalConfigs {
   Promise: PromiseConstructor | null
   fetch: typeof fetch | null
   gateway: Gateway | null
-  gatewayConfigs: Partial<GatewayConfiguration>
+  gatewayConfigs: GatewayConfiguration
   maxMiddlewareStackExecutionAllowed: number
 }
 
@@ -64,7 +64,7 @@ export class Manifest<Resources extends ResourceTypeConstraint> {
   public timeoutAttr?: string
   public hostAttr?: string
   public clientId: string | null
-  public gatewayConfigs: Partial<GatewayConfiguration>
+  public gatewayConfigs: GatewayConfiguration
   public resources: Resources
   public context: Context
   public middleware: Middleware[]

--- a/src/mappersmith.js
+++ b/src/mappersmith.js
@@ -1,6 +1,10 @@
 /* global VERSION */
 import ClientBuilder from './client-builder'
 import { assign } from './utils'
+/**
+ * Can be used to test for `instanceof Response`
+ */
+export { Response } from './response'
 
 export const version = VERSION
 

--- a/src/response.spec.ts
+++ b/src/response.spec.ts
@@ -113,7 +113,7 @@ describe('Response', () => {
 
   describe('#data', () => {
     it('returns the response data', () => {
-      expect(response.data<string>()).toEqual(responseData)
+      expect(response.data()).toEqual(responseData)
     })
 
     describe('when responseData is JSON', () => {

--- a/src/response.ts
+++ b/src/response.ts
@@ -19,7 +19,7 @@ export interface ResponseParams {
  * @param {Object} responseHeaders, defaults to an empty object ({})
  * @param {Array<Error>} errors, defaults to an empty array ([])
  */
-export class Response<DataType extends object | string | null = object> {
+export class Response<DataType = unknown> {
   public readonly originalRequest: Request
   public readonly responseStatus: number
   public readonly responseData: string | null
@@ -104,14 +104,14 @@ export class Response<DataType extends object | string | null = object> {
    * Friendly reminder:
    *  - JSON.parse() can return null, an Array or an object.
    */
-  public data(): DataType {
+  public data() {
     if (this.isContentTypeJSON() && this.responseData !== null) {
       try {
         return JSON.parse(this.responseData) as DataType
       } catch (e) {} // eslint-disable-line no-empty
     }
 
-    return this.responseData as DataType
+    return this.responseData
   }
 
   public isContentTypeJSON() {

--- a/src/response.ts
+++ b/src/response.ts
@@ -19,7 +19,7 @@ export interface ResponseParams {
  * @param {Object} responseHeaders, defaults to an empty object ({})
  * @param {Array<Error>} errors, defaults to an empty array ([])
  */
-export class Response {
+export class Response<DataType extends object | string | null = object> {
   public readonly originalRequest: Request
   public readonly responseStatus: number
   public readonly responseData: string | null
@@ -104,7 +104,7 @@ export class Response {
    * Friendly reminder:
    *  - JSON.parse() can return null, an Array or an object.
    */
-  public data<DataType extends object | string | null>(): DataType {
+  public data(): DataType {
     if (this.isContentTypeJSON() && this.responseData !== null) {
       try {
         return JSON.parse(this.responseData) as DataType
@@ -148,7 +148,7 @@ export class Response {
    */
   public enhance(extras: ResponseParams) {
     const mergedHeaders = { ...this.headers(), ...(extras.headers || {}) }
-    const enhancedResponse = new Response(
+    const enhancedResponse = new Response<DataType>(
       this.request(),
       extras.status || this.status(),
       extras.rawData || this.rawData() || undefined,

--- a/src/response.ts
+++ b/src/response.ts
@@ -19,7 +19,9 @@ export interface ResponseParams {
  * @param {Object} responseHeaders, defaults to an empty object ({})
  * @param {Array<Error>} errors, defaults to an empty array ([])
  */
-export class Response<DataType = unknown> {
+type SerializableJSON = number | string | boolean | null | Record<string, unknown>
+export type ParsedJSON = SerializableJSON | SerializableJSON[]
+export class Response<DataType extends ParsedJSON = ParsedJSON> {
   public readonly originalRequest: Request
   public readonly responseStatus: number
   public readonly responseData: string | null

--- a/src/response.ts
+++ b/src/response.ts
@@ -104,14 +104,14 @@ export class Response<DataType = unknown> {
    * Friendly reminder:
    *  - JSON.parse() can return null, an Array or an object.
    */
-  public data() {
+  public data<T = DataType>() {
     if (this.isContentTypeJSON() && this.responseData !== null) {
       try {
-        return JSON.parse(this.responseData) as DataType
+        return JSON.parse(this.responseData) as T
       } catch (e) {} // eslint-disable-line no-empty
     }
 
-    return this.responseData
+    return this.responseData as unknown as T
   }
 
   public isContentTypeJSON() {

--- a/src/test.js
+++ b/src/test.js
@@ -3,6 +3,9 @@ import MockResource from './mocks/mock-resource'
 import MockGateway from './gateway/mock'
 import { configs } from './index'
 import { toQueryString } from './utils'
+import { MethodDescriptor } from './method-descriptor'
+import { Request } from './request'
+import { Response } from './response'
 
 let store = []
 let ids = 1
@@ -177,4 +180,39 @@ const stringIncludes = (str, search, start) => {
   }
 
   return str.indexOf(search, start) !== -1
+}
+
+/**
+ * Create a response to use in tests
+ * @returns Response
+ */
+export const responseFactory = ({
+  method = 'get',
+  host = 'http://example.org',
+  path = '/path',
+  status = 200,
+  data = {},
+  headers = {},
+  errors = [],
+}) => {
+  const methodDescriptor = new MethodDescriptor({ method, host, path })
+  const request = new Request(methodDescriptor)
+
+  let responseData
+  let contentType
+  if (typeof data === 'string') {
+    contentType = 'text/plain'
+    responseData = data
+  } else {
+    contentType = 'application/json'
+    responseData = JSON.stringify(data)
+  }
+
+  return new Response(
+    request,
+    status,
+    responseData,
+    { 'content-type': contentType, ...headers },
+    errors
+  )
 }

--- a/src/test.js
+++ b/src/test.js
@@ -183,20 +183,45 @@ const stringIncludes = (str, search, start) => {
 }
 
 /**
+ * Create a request to use in tests
+ * @returns Request
+ */
+export const requestFactory = ({
+  method = 'GET',
+  host = 'http://example.org',
+  path = '/path',
+  auth,
+  body,
+  headers,
+  params,
+  timeout,
+  ...rest
+} = {}) => {
+  const methodDescriptor = new MethodDescriptor({ method, host, path })
+  return new Request(methodDescriptor, {
+    auth,
+    body,
+    headers,
+    params,
+    timeout,
+    ...rest,
+  })
+}
+
+/**
  * Create a response to use in tests
  * @returns Response
  */
 export const responseFactory = ({
-  method = 'get',
+  method = 'GET',
   host = 'http://example.org',
   path = '/path',
   status = 200,
   data = {},
   headers = {},
   errors = [],
-}) => {
-  const methodDescriptor = new MethodDescriptor({ method, host, path })
-  const request = new Request(methodDescriptor)
+} = {}) => {
+  const request = requestFactory({ method, host, path })
 
   let responseData
   let contentType

--- a/src/test.spec.js
+++ b/src/test.spec.js
@@ -1,0 +1,135 @@
+import { Request } from './request'
+import { Response } from './response'
+import { MethodDescriptor } from './method-descriptor'
+import { requestFactory, responseFactory } from './test'
+
+describe('mappersmith/test', () => {
+  const method = 'GET'
+  const host = 'http://example.org'
+  const path = '/path'
+  let methodDescriptor
+
+  beforeEach(() => {
+    methodDescriptor = new MethodDescriptor({ method, host, path })
+  })
+
+  describe('#requestFactory', () => {
+    it('creates a request with a default method descriptor', async () => {
+      const request = requestFactory()
+      expect(request).toEqual(new Request(methodDescriptor))
+    })
+
+    it('accepts params to customize it', async () => {
+      const requestParams = {
+        auth: {
+          'auth-key': 'auth-value',
+        },
+        body: {
+          'body-key': 'body-value',
+        },
+        headers: {
+          'my-header': 'my-header-value',
+        },
+        params: {
+          group: 'general',
+        },
+        timeout: 20,
+        'a key': 'a value',
+      }
+      const methodDescriptorParams = {
+        method: 'POST',
+        host: 'http://example.org',
+        path: '/users/{group}',
+      }
+
+      const request = requestFactory({
+        ...methodDescriptorParams,
+        ...requestParams,
+      })
+
+      expect(request).toEqual(
+        new Request(new MethodDescriptor(methodDescriptorParams), requestParams)
+      )
+    })
+  })
+
+  describe('#responseFactory', () => {
+    let request
+
+    beforeEach(() => {
+      methodDescriptor = new MethodDescriptor({ method, host, path })
+      request = new Request(methodDescriptor)
+    })
+
+    it('creates a response with a default request', async () => {
+      const response = responseFactory()
+      expect(response).toEqual(
+        new Response(request, 200, '{}', { 'content-type': 'application/json' })
+      )
+    })
+
+    it('accepts params to customize it', async () => {
+      const status = 204
+      const data = { foo: 'bar' }
+      const headers = {
+        'my-header': 'my-header-value',
+      }
+      const errors = [new Error('an error')]
+
+      const methodDescriptorParams = {
+        method: 'POST',
+        host: 'http://example.org',
+        path: '/users/{group}',
+      }
+
+      const response = responseFactory({
+        ...methodDescriptorParams,
+        status,
+        data,
+        headers,
+        errors,
+      })
+
+      request = requestFactory(methodDescriptorParams)
+
+      expect(response).toEqual(
+        new Response(
+          request,
+          status,
+          JSON.stringify(data),
+          {
+            'content-type': 'application/json',
+            ...headers,
+          },
+          errors
+        )
+      )
+    })
+
+    it('accepts data as string or JSON and sets content-type accordingly', async () => {
+      const jsonData = { foo: 'bar' }
+
+      expect(
+        responseFactory({
+          data: jsonData,
+        })
+      ).toEqual(
+        new Response(requestFactory(), 200, JSON.stringify(jsonData), {
+          'content-type': 'application/json',
+        })
+      )
+
+      const stringData = 'the returned text'
+
+      expect(
+        responseFactory({
+          data: stringData,
+        })
+      ).toEqual(
+        new Response(requestFactory(), 200, stringData, {
+          'content-type': 'text/plain',
+        })
+      )
+    })
+  })
+})

--- a/typings/generated/src/gateway/types.d.ts
+++ b/typings/generated/src/gateway/types.d.ts
@@ -34,20 +34,20 @@ export interface NetworkGateway {
 }
 export interface XhrGateway extends Gateway, NetworkGateway {
     readonly withCredentials: boolean;
-    configure?: ((xmlHttpRequest: XMLHttpRequest) => void) | null;
-    configureBinary(xmlHttpRequest: XMLHttpRequest): void;
-    configureCallbacks(xmlHttpRequest: XMLHttpRequest): void;
-    configureTimeout(xmlHttpRequest: XMLHttpRequest): void;
-    createResponse(xmlHttpRequest: XMLHttpRequest): void;
-    createXHR(): XMLHttpRequest;
-    performRequest(method: string): void;
-    setHeaders(xmlHttpRequest: XMLHttpRequest, headers: Headers): void;
+    configure: ((xmlHttpRequest: XMLHttpRequest) => void) | null;
+    configureBinary?: (xmlHttpRequest: XMLHttpRequest) => void;
+    configureCallbacks?: (xmlHttpRequest: XMLHttpRequest) => void;
+    configureTimeout?: (xmlHttpRequest: XMLHttpRequest) => void;
+    createResponse?: (xmlHttpRequest: XMLHttpRequest) => void;
+    setHeaders?: (xmlHttpRequest: XMLHttpRequest, headers: Headers) => void;
+    createXHR?(): XMLHttpRequest;
+    performRequest?(method: string): void;
 }
 export interface GatewayConfiguration {
     Fetch: object;
     HTTP: HTTPGatewayConfiguration;
     Mock?: object;
     XHR: Partial<XhrGateway>;
-    enableHTTP408OnTimeouts?: boolean;
-    emulateHTTP?: boolean;
+    enableHTTP408OnTimeouts: boolean;
+    emulateHTTP: boolean;
 }

--- a/typings/generated/src/gateway/types.d.ts
+++ b/typings/generated/src/gateway/types.d.ts
@@ -34,14 +34,14 @@ export interface NetworkGateway {
 }
 export interface XhrGateway extends Gateway, NetworkGateway {
     readonly withCredentials: boolean;
-    configure: ((xmlHttpRequest: XMLHttpRequest) => void) | null;
-    configureBinary?: (xmlHttpRequest: XMLHttpRequest) => void;
-    configureCallbacks?: (xmlHttpRequest: XMLHttpRequest) => void;
-    configureTimeout?: (xmlHttpRequest: XMLHttpRequest) => void;
-    createResponse?: (xmlHttpRequest: XMLHttpRequest) => void;
-    setHeaders?: (xmlHttpRequest: XMLHttpRequest, headers: Headers) => void;
-    createXHR?(): XMLHttpRequest;
-    performRequest?(method: string): void;
+    configure?: ((xmlHttpRequest: XMLHttpRequest) => void) | null;
+    configureBinary(xmlHttpRequest: XMLHttpRequest): void;
+    configureCallbacks(xmlHttpRequest: XMLHttpRequest): void;
+    configureTimeout(xmlHttpRequest: XMLHttpRequest): void;
+    createResponse(xmlHttpRequest: XMLHttpRequest): void;
+    createXHR(): XMLHttpRequest;
+    performRequest(method: string): void;
+    setHeaders(xmlHttpRequest: XMLHttpRequest, headers: Headers): void;
 }
 export interface GatewayConfiguration {
     Fetch: object;

--- a/typings/generated/src/manifest.d.ts
+++ b/typings/generated/src/manifest.d.ts
@@ -8,7 +8,7 @@ export interface GlobalConfigs {
     Promise: PromiseConstructor | null;
     fetch: typeof fetch | null;
     gateway: Gateway | null;
-    gatewayConfigs: Partial<GatewayConfiguration>;
+    gatewayConfigs: GatewayConfiguration;
     maxMiddlewareStackExecutionAllowed: number;
 }
 export declare type ResourceTypeConstraint = {
@@ -62,7 +62,7 @@ export declare class Manifest<Resources extends ResourceTypeConstraint> {
     timeoutAttr?: string;
     hostAttr?: string;
     clientId: string | null;
-    gatewayConfigs: Partial<GatewayConfiguration>;
+    gatewayConfigs: GatewayConfiguration;
     resources: Resources;
     context: Context;
     middleware: Middleware[];

--- a/typings/generated/src/response.d.ts
+++ b/typings/generated/src/response.d.ts
@@ -14,7 +14,9 @@ export interface ResponseParams {
  * @param {Object} responseHeaders, defaults to an empty object ({})
  * @param {Array<Error>} errors, defaults to an empty array ([])
  */
-export declare class Response<DataType = unknown> {
+declare type SerializableJSON = number | string | boolean | null | Record<string, unknown>;
+export declare type ParsedJSON = SerializableJSON | SerializableJSON[];
+export declare class Response<DataType extends ParsedJSON = ParsedJSON> {
     readonly originalRequest: Request;
     readonly responseStatus: number;
     readonly responseData: string | null;

--- a/typings/generated/src/response.d.ts
+++ b/typings/generated/src/response.d.ts
@@ -14,7 +14,7 @@ export interface ResponseParams {
  * @param {Object} responseHeaders, defaults to an empty object ({})
  * @param {Array<Error>} errors, defaults to an empty array ([])
  */
-export declare class Response {
+export declare class Response<DataType extends object | string | null = object> {
     readonly originalRequest: Request;
     readonly responseStatus: number;
     readonly responseData: string | null;
@@ -47,7 +47,7 @@ export declare class Response {
      * Friendly reminder:
      *  - JSON.parse() can return null, an Array or an object.
      */
-    data<DataType extends object | string | null>(): DataType;
+    data(): DataType;
     isContentTypeJSON(): boolean;
     /**
      * Returns the last error instance that caused the request to fail
@@ -62,6 +62,6 @@ export declare class Response {
      *   @param {Object} extras.headers - it will be merged with current headers
      *   @param {Error} extras.error    - it will be added to the list of errors
      */
-    enhance(extras: ResponseParams): Response;
+    enhance(extras: ResponseParams): Response<DataType>;
 }
 export default Response;

--- a/typings/generated/src/response.d.ts
+++ b/typings/generated/src/response.d.ts
@@ -47,7 +47,7 @@ export declare class Response<DataType = unknown> {
      * Friendly reminder:
      *  - JSON.parse() can return null, an Array or an object.
      */
-    data(): string | DataType | null;
+    data<T = DataType>(): T;
     isContentTypeJSON(): boolean;
     /**
      * Returns the last error instance that caused the request to fail

--- a/typings/generated/src/response.d.ts
+++ b/typings/generated/src/response.d.ts
@@ -14,7 +14,7 @@ export interface ResponseParams {
  * @param {Object} responseHeaders, defaults to an empty object ({})
  * @param {Array<Error>} errors, defaults to an empty array ([])
  */
-export declare class Response<DataType extends object | string | null = object> {
+export declare class Response<DataType = unknown> {
     readonly originalRequest: Request;
     readonly responseStatus: number;
     readonly responseData: string | null;
@@ -47,7 +47,7 @@ export declare class Response<DataType extends object | string | null = object> 
      * Friendly reminder:
      *  - JSON.parse() can return null, an Array or an object.
      */
-    data(): DataType;
+    data(): string | DataType | null;
     isContentTypeJSON(): boolean;
     /**
      * Returns the last error instance that caused the request to fail

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,7 +23,8 @@ declare module 'mappersmith' {
     import('./generated/src/gateway/types').HTTPGatewayConfiguration
   export type GatewayConfiguration = import('./generated/src/gateway/types').GatewayConfiguration
   type ParameterEncoderFn = import('./generated/src/types').ParameterEncoderFn
-  export type Response<DataType = unknown> = import('./generated/src/response').Response<DataType>
+  export class Response<DataType = unknown> extends (await import('./generated/src/response'))
+    .Response<DataType> {}
 
   export type AbortFn = import('./generated/src/middleware').AbortFn
   export type Authorization = import('./generated/src/middleware').Authorization

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,7 +23,7 @@ declare module 'mappersmith' {
     import('./generated/src/gateway/types').HTTPGatewayConfiguration
   export type GatewayConfiguration = import('./generated/src/gateway/types').GatewayConfiguration
   type ParameterEncoderFn = import('./generated/src/types').ParameterEncoderFn
-  export type Response = import('./generated/src/response').Response
+  export type Response<DataType = unknown> = import('./generated/src/response').Response<DataType>
 
   export type AbortFn = import('./generated/src/middleware').AbortFn
   export type Authorization = import('./generated/src/middleware').Authorization

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,8 +23,10 @@ declare module 'mappersmith' {
     import('./generated/src/gateway/types').HTTPGatewayConfiguration
   export type GatewayConfiguration = import('./generated/src/gateway/types').GatewayConfiguration
   type ParameterEncoderFn = import('./generated/src/types').ParameterEncoderFn
-  export class Response<DataType = unknown> extends (await import('./generated/src/response'))
-    .Response<DataType> {}
+  export type ParsedJSON = import('./generated/src/response').ParsedJSON
+  export class Response<DataType extends ParsedJSON = ParsedJSON> extends (
+    await import('./generated/src/response')
+  ).Response<DataType> {}
 
   export type AbortFn = import('./generated/src/middleware').AbortFn
   export type Authorization = import('./generated/src/middleware').Authorization

--- a/typings/test.d.ts
+++ b/typings/test.d.ts
@@ -1,5 +1,5 @@
 declare module 'mappersmith/test' {
-  import { Client, Parameters, Response, Request, Headers } from 'mappersmith'
+  import { Client, Parameters, Response, Request, Headers, ParsedJSON } from 'mappersmith'
 
   export interface MockAssert {
     calls(): Request[]
@@ -72,7 +72,7 @@ declare module 'mappersmith/test' {
     headers?: Record<string, string | number | boolean>
     errors?: Array<Error | string>
   }
-  export function responseFactory<T>(args?: ResponseFactoryArgs<T>): Response<T>
+  export function responseFactory<T extends ParsedJSON>(args?: ResponseFactoryArgs<T>): Response<T>
 
   type Primitive = string | number | boolean
 

--- a/typings/test.d.ts
+++ b/typings/test.d.ts
@@ -1,5 +1,5 @@
 declare module 'mappersmith/test' {
-  import { Client, Parameters, Request, Headers } from 'mappersmith'
+  import { Client, Parameters, Response, Request, Headers } from 'mappersmith'
 
   export interface MockAssert {
     calls(): Request[]
@@ -62,6 +62,17 @@ declare module 'mappersmith/test' {
   }
 
   export function mockRequest(args: MockRequestArgs): MockAssert
+
+  export interface ResponseFactoryArgs<T> {
+    method?: string
+    host?: string
+    path?: string
+    status?: number
+    data?: T | string
+    headers?: Record<string, string | number | boolean>
+    errors?: Array<Error | string>
+  }
+  export function responseFactory<T>(args: ResponseFactoryArgs<T>): Response<T>
 
   export const m: TestMatchFunctions
 }

--- a/typings/test.d.ts
+++ b/typings/test.d.ts
@@ -72,7 +72,32 @@ declare module 'mappersmith/test' {
     headers?: Record<string, string | number | boolean>
     errors?: Array<Error | string>
   }
-  export function responseFactory<T>(args: ResponseFactoryArgs<T>): Response<T>
+  export function responseFactory<T>(args?: ResponseFactoryArgs<T>): Response<T>
+
+  type Primitive = string | number | boolean
+
+  interface Auth {
+    readonly [key: string]: Primitive
+  }
+
+  interface Params {
+    readonly [key: string]: object | Primitive | undefined | null
+  }
+
+  export interface RequestFactoryArgs {
+    // MethodDescriptorParams
+    method?: string
+    host?: string
+    path?: string
+    // RequestParams
+    auth?: Auth
+    body?: object | string
+    headers?: Headers
+    params?: Params
+    timeout?: number
+    [param: string]: object | Primitive | undefined | null
+  }
+  export function requestFactory(args?: RequestFactoryArgs): Request
 
   export const m: TestMatchFunctions
 }


### PR DESCRIPTION
Improves the developer ergonomics of typing client responses: #263 

The generic defaults to `ParsedJSON` 