### PR TITLE
Adding enableRetry as an config function for retry middleware

### DIFF
--- a/spec/typescript/middleware/retry-v2.spec.ts
+++ b/spec/typescript/middleware/retry-v2.spec.ts
@@ -9,6 +9,7 @@ const retryConfigs: RetryMiddlewareOptions = {
   factor: 0.2, // randomization factor
   multiplier: 2, // exponential factor
   retries: 5, // max retries
+  enableRetry: (request) => request.method() === 'get', // a function that returns true if retry should be enabled
   validateRetry: (response) => response.responseStatus >= 500, // a function that returns true if the request should be retried
 }
 

--- a/typings/middleware/retry-v2.d.ts
+++ b/typings/middleware/retry-v2.d.ts
@@ -1,5 +1,5 @@
 declare module 'mappersmith/middleware/retry/v2' {
-  import { Middleware, Response } from 'mappersmith'
+  import { Middleware, Request, Response } from 'mappersmith'
 
   export interface RetryMiddlewareOptions {
     readonly headerRetryCount: string
@@ -9,6 +9,7 @@ declare module 'mappersmith/middleware/retry/v2' {
     readonly factor: number
     readonly multiplier: number
     readonly retries: number
+    enableRetry(request: Request): boolean
     validateRetry(response: Response): boolean
   }
 


### PR DESCRIPTION
Retry middleware only supports GET requests. This is an issue when used for GraphQL query requests since they are made as a POST. 

This PR adds the option to override the default enableRetry configuration.