### PR TITLE
Add encoder function also for query params

### DIFF
--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -218,6 +218,17 @@ describe('Request', () => {
       expect(path).toEqual('/api/example.json?email=email%2Btest%40example.com')
     })
 
+    it('encodes query string params with custom encoding function if passed', () => {
+      const methodDescriptor = new MethodDescriptor({
+        ...methodDescriptorArgs,
+        params: { code: 'my:code-123' },
+        parameterEncoder: (arg) => encodeURI(arg.toString()),
+        path: 'api/example.json',
+      })
+      const path = new Request(methodDescriptor).path()
+      expect(path).toEqual('/api/example.json?code=my:code-123')
+    })
+
     it('appends the query string with a leading & if the path has a hard-coded query string', () => {
       const methodDescriptor = new MethodDescriptor({
         ...methodDescriptorArgs,
@@ -260,6 +271,17 @@ describe('Request', () => {
       expect(path).toEqual(
         '/api/example.json?userTransactionsIds%5B%5D=2&userTransactionsIds%5B%5D=3'
       )
+    })
+
+    it('encodes arrays with custom encoding function if passed', () => {
+      const methodDescriptor = new MethodDescriptor({
+        ...methodDescriptorArgs,
+        params: { userTransactionsIds: [2, 3] },
+        parameterEncoder: (arg) => arg.toString().replace(/(\[|\])/g, ''),
+        path: '/api/example.json',
+      })
+      const path = new Request(methodDescriptor).path()
+      expect(path).toEqual('/api/example.json?userTransactionsIds=2&userTransactionsIds=3')
     })
 
     it('encodes objects in the param[key]=value format', () => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -142,7 +142,7 @@ export class Request {
       return aliased
     }, {} as Record<string, Primitive | NestedParam | NestedParamArray>)
 
-    const queryString = toQueryString(aliasedParams)
+    const queryString = toQueryString(aliasedParams, this.methodDescriptor.parameterEncoder)
     if (typeof queryString === 'string' && queryString.length !== 0) {
       const hasQuery = path.includes('?')
       path += `${hasQuery ? '&' : '?'}${queryString}`

--- a/src/utils/index.spec.ts
+++ b/src/utils/index.spec.ts
@@ -30,6 +30,24 @@ describe('utils', () => {
         expect(toQueryString(params)).toEqual('a=some+big+string')
       })
 
+      it('encodes with the default function if no fn parameter is passed', () => {
+        expect(toQueryString({ a: 'mock:code:123-456' })).toEqual('a=mock%3Acode%3A123-456')
+      })
+
+      it('encodes string properties with a custom function if passed', () => {
+        expect(
+          toQueryString({ a: 'mock:code:123-456' }, (arg) => encodeURI(arg.toString()))
+        ).toEqual('a=mock:code:123-456')
+      })
+
+      it('encodes array properties with a custom function if passed', () => {
+        expect(
+          toQueryString({ a: ['mock:code:123-456', 'mock:code:789-012'] }, (arg) =>
+            encodeURI(arg.toString().replace(/(\[|\])/g, ''))
+          )
+        ).toEqual('a=mock:code:123-456&a=mock:code:789-012')
+      })
+
       describe('in blank', () => {
         it('returns an empty string', () => {
           expect(toQueryString({})).toEqual('')

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,21 +34,22 @@ export const validKeys = (entry: Record<string, unknown>) =>
 export const buildRecursive = (
   key: string,
   value: Primitive | NestedParam | NestedParamArray,
-  suffix = ''
+  suffix = '',
+  encoderFn = encodeURIComponent
 ): string => {
   if (Array.isArray(value)) {
-    return value.map((v) => buildRecursive(key, v, suffix + '[]')).join('&')
+    return value.map((v) => buildRecursive(key, v, suffix + '[]', encoderFn)).join('&')
   }
 
   if (typeof value !== 'object') {
-    return `${encodeURIComponent(key + suffix)}=${encodeURIComponent(value)}`
+    return `${encoderFn(key + suffix)}=${encoderFn(value)}`
   }
 
   return Object.keys(value)
     .map((nestedKey) => {
       const nestedValue = value[nestedKey]
       if (isNeitherNullNorUndefined(nestedValue)) {
-        return buildRecursive(key, nestedValue, suffix + '[' + nestedKey + ']')
+        return buildRecursive(key, nestedValue, suffix + '[' + nestedKey + ']', encoderFn)
       }
       return null
     })
@@ -56,7 +57,10 @@ export const buildRecursive = (
     .join('&')
 }
 
-export const toQueryString = (entry: undefined | null | Primitive | NestedParam) => {
+export const toQueryString = (
+  entry: undefined | null | Primitive | NestedParam,
+  encoderFn = encodeURIComponent
+) => {
   if (!isPlainObject(entry)) {
     return entry
   }
@@ -65,7 +69,7 @@ export const toQueryString = (entry: undefined | null | Primitive | NestedParam)
     .map((key) => {
       const value = entry[key]
       if (isNeitherNullNorUndefined(value)) {
-        return buildRecursive(key, value)
+        return buildRecursive(key, value, '', encoderFn)
       }
       return null
     })


### PR DESCRIPTION
Following the logic of [this PR](https://github.com/tulios/mappersmith/pull/251/commits/afbb12731fff6a008b37afb81d11e79b54f17c6c), it's useful to have the encoding function used for the query parameters.