### PR TITLE
Fix: Allow `Buffer` (and similar) as valid response data for `mockRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Fixed:
   - `mappersmith`: Preserve `rawData` as empty string instead of converting it to null #297
+  - `mappersmith/test`: Allow `Buffer` (and similar) as valid response data for `mockRequest` #299
 
 ## 2.38.0
 

--- a/spec/browser/test/mock-request.spec.js
+++ b/spec/browser/test/mock-request.spec.js
@@ -152,6 +152,53 @@ describe('Test lib / mock request', () => {
       })
   })
 
+  it('works with buffer request body', (done) => {
+    const buffer = Buffer.from('xxx')
+    mockRequest({
+      method: 'post',
+      url: 'http://example.org/blogs',
+      body: buffer,
+      response: {
+        body: 'just text!',
+      },
+    })
+
+    client.Blog.post({ body: buffer })
+      .then((response) => {
+        expect(response.request().method()).toEqual('post')
+        expect(response.status()).toEqual(200)
+        expect(response.data()).toEqual('just text!')
+        done()
+      })
+      .catch((response) => {
+        const error = response.rawData ? response.rawData() : response
+        done.fail(`test failed with promise error: ${error}`)
+      })
+  })
+
+  it('works with buffer response body', (done) => {
+    const buffer = Buffer.from('xxx')
+    mockRequest({
+      method: 'post',
+      url: 'http://example.org/blogs',
+      response: {
+        body: buffer,
+      },
+    })
+
+    client.Blog.post()
+      .then((response) => {
+        expect(response.request().method()).toEqual('post')
+        expect(response.status()).toEqual(200)
+        expect(response.data()).toEqual(buffer)
+        done()
+      })
+      .catch((response) => {
+        const error = response.rawData ? response.rawData() : response
+        done.fail(`test failed with promise error: ${error}`)
+      })
+  })
+
   it('accepts a matcher function as a body', (done) => {
     mockRequest({
       method: 'post',

--- a/src/utils/clone.spec.ts
+++ b/src/utils/clone.spec.ts
@@ -59,7 +59,7 @@ describe('utils', () => {
     })
 
     describe('for class instance object', () => {
-      it('returns a clone of the original entry', () => {
+      it('does not return a clone of the original entry', () => {
         class Character {
           public name: string
           constructor({ name }: { name: string }) {
@@ -69,8 +69,16 @@ describe('utils', () => {
         const original = new Character({ name: 'Piglet' })
         const copy = clone(original)
         copy.name = 'Tiggr'
-        expect(original).toEqual(new Character({ name: 'Piglet' }))
-        expect(copy).toEqual(new Character({ name: 'Tiggr' }))
+        expect(original).toEqual(new Character({ name: 'Tiggr' }))
+      })
+    })
+
+    describe('for Buffer instance object (and similar)', () => {
+      it('does not return a clone of the original entry', () => {
+        const original = Buffer.from('piglet')
+        const copy = clone(original)
+        copy.fill('x')
+        expect(original).toEqual(Buffer.from('xxxxxx'))
       })
     })
 

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -1,7 +1,7 @@
-import { isObject } from './index'
+import { isPlainObject, isObject } from './index'
 
 export const clone = <T>(obj: T): T => {
-  if (isObject(obj)) {
+  if (isPlainObject(obj)) {
     return cloneObject(obj)
   } else if (Array.isArray(obj)) {
     return cloneArray(obj)


### PR DESCRIPTION
Fixes #299 