### PR TITLE
Ensure references to `regeneratorRuntime` is not part of compiled bundle

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,5 +1,13 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-typescript'],
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        exclude: ['@babel/plugin-transform-regenerator'],
+      },
+    ],
+    '@babel/preset-typescript',
+  ],
   plugins: [
     '@babel/plugin-proposal-class-properties',
     '@babel/proposal-object-rest-spread',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Fixed:
   - `mappersmith`: Preserve `rawData` as empty string instead of converting it to null #297
   - `mappersmith/test`: Allow `Buffer` (and similar) as valid response data for `mockRequest` #299
+  - `mappersmith`: Ensure references to `regeneratorRuntime` is not part of compiled bundle #303
 
 ## 2.38.0
 


### PR DESCRIPTION
Fixes #303 