### PR TITLE
Properly merge headers when one of the sides is a mock matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+Fixed:
+  - `mappersmith/test`: Properly merge headers when one of the sides is a mock matcher #316
+
 ## 2.39.1
 
 Fixed:

--- a/spec/browser/test/mock-request.spec.js
+++ b/spec/browser/test/mock-request.spec.js
@@ -377,6 +377,41 @@ describe('Test lib / mock request', () => {
     expect(response.status()).toEqual(200)
   })
 
+  it('allows for header matchers to override default headers', async () => {
+    mockClient(client)
+      .resource('Feed')
+      .method('add')
+      .with({
+        body: m.anything(),
+        headers: m.anything(),
+      })
+      .status(200)
+      .assertObject()
+
+    const manifest = getManifest()
+
+    const clientWithoutHeaders = forge({
+      ...manifest,
+      resources: {
+        ...manifest.resources,
+        Feed: {
+          add: {
+            ...manifest.resources.Feed.add,
+            // We remove the headers so requests in this client won't include them,
+            // but that shouldn't matter because the mock has `headers: m.anything()`
+            headers: {},
+          },
+        },
+      },
+    })
+
+    const response = await clientWithoutHeaders.Feed.add({
+      headers: { 'x-any-other-header': false },
+    })
+
+    expect(response.status()).toEqual(200)
+  })
+
   describe('unused mocks', () => {
     it('returns count of all unused mockClients', async () => {
       mockClient(client).resource('Blog').method('post')

--- a/spec/ts-helper.ts
+++ b/spec/ts-helper.ts
@@ -13,6 +13,9 @@ const resources = {
     post: { method: 'post', path: '/blogs' },
     addComment: { method: 'put', path: '/blogs/{id}/comment' },
   },
+  Feed: {
+    add: { method: 'post', path: '/feed', headers: { 'x-feed-entry': true } },
+  },
 }
 
 export const getManifest = (

--- a/src/request.ts
+++ b/src/request.ts
@@ -185,6 +185,11 @@ export class Request {
   public headers() {
     const headerAttr = this.methodDescriptor.headersAttr
     const headers = (this.requestParams[headerAttr] || {}) as Headers
+
+    if (typeof headers === 'function') {
+      return headers
+    }
+
     const mergedHeaders = { ...this.methodDescriptor.headers, ...headers } as Headers
     return lowerCaseObjectKeys(mergedHeaders) as Headers
   }


### PR DESCRIPTION
Closes #316