### PR TITLE
Response.errors should not be allowed an instance of Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+Fixed:
+  - `mappersmith`: `Response.errors` should only be allowed to contain `Error` or `string` #325
+
 ## 2.40.0
 
 Fixed:

--- a/src/middleware/retry/v2/index.ts
+++ b/src/middleware/retry/v2/index.ts
@@ -129,7 +129,7 @@ const retriableRequest: RetriableRequestFn = (resolve, reject, next, request) =>
             if (typeof e === 'object' && e !== null && 'message' in e) {
               errorMessage = (e as Record<'message', string>).message
             }
-            reject(new Response(request, 400, errorMessage, {}, [response]))
+            reject(new Response(request, 400, errorMessage, {}, [new Error(errorMessage)]))
           }
         }
       })

--- a/src/response.ts
+++ b/src/response.ts
@@ -27,7 +27,7 @@ export class Response<DataType extends ParsedJSON = ParsedJSON> {
   public readonly responseData: string | null
   public readonly responseHeaders: Headers
   // eslint-disable-next-line no-use-before-define
-  public readonly errors: Array<Response | Error | string>
+  public readonly errors: Array<Error | string>
   public timeElapsed: number | null
 
   constructor(
@@ -35,7 +35,7 @@ export class Response<DataType extends ParsedJSON = ParsedJSON> {
     responseStatus: number,
     responseData?: string | null,
     responseHeaders?: Headers,
-    errors?: Array<Response | Error | string>
+    errors?: Array<Error | string>
   ) {
     const auth = originalRequest.requestParams && originalRequest.requestParams.auth
     if (auth) {


### PR DESCRIPTION
- This was typed like this to be compatible with RetryMiddleware
- RetryMiddlewareV2 will no longer have Response in it. Although this is a "breaking" change, I don't think it's a big deal as A) it's a built in middleware that is opt-in (should be its own package tbh) and B) people can still push to it if they cast it as any.