### PR TITLE
Allow path to be set by Request.enhance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Fixed:
   - `mappersmith`: Allow path to be empty string in manifest #327
   - `mappersmith`: `Response.errors` should only be allowed to contain `Error` or `string` #325
 
+Added:
+  - `mappersmith`: Accept `path` as a resource method param
+
 ## 2.40.0
 
 Fixed:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ __Mappersmith__ is a lightweight rest client for node.js and the browser. It cre
     - [Basic Auth](#basic-auth)
     - [Timeout](#timeout)
     - [Alternative host](#alternative-host)
+    - [Alternative path](#alternative-path)
     - [Binary data](#binary-data)
   - [Promises](#promises)
   - [Response object](#response-object)
@@ -369,6 +370,32 @@ const client = forge({
 ```
 
 Whenever using host overrides, be diligent about how you pass parameters to your resource methods. If you spread unverified attributes, you might open your server to SSR attacks.
+
+### <a name="alternative-path"></a> Alternative path
+
+In case you need to overwrite the path for a specific call, you can do so through the param `path`:
+
+```javascript
+// ...
+{
+  all: { path: '/users' }
+}
+// ...
+
+client.User.all({ path: '/people' })
+```
+
+If `path` is not possible as a special parameter for your API, you can configure it through the param `pathAttr`:
+
+```javascript
+// ...
+{
+  all: { path: '/users', pathAttr: '__path' }
+}
+// ...
+
+client.User.all({ __path: '/people' })
+```
 
 ### <a name="binary-data"></a> Binary data
 

--- a/src/method-descriptor.ts
+++ b/src/method-descriptor.ts
@@ -16,6 +16,7 @@ export interface MethodDescriptorParams {
   middlewares?: Array<Middleware>
   params?: Params
   path: string | ((args: RequestParams) => string)
+  pathAttr?: string
   queryParamAlias?: Record<string, string>
   timeoutAttr?: string
 }
@@ -37,6 +38,7 @@ export interface MethodDescriptorParams {
  *   @param {Middleware[]} params.middlewares - alias for middleware
  *   @param {RequestParams} params.params
  *   @param {String|Function} params.path
+ *   @param {String} params.pathAttr. Default: 'path'
  *   @param {Object} params.queryParamAlias
  *   @param {Number} params.timeoutAttr - timeout attribute name. Default: 'timeout'
  */
@@ -54,6 +56,7 @@ export class MethodDescriptor {
   public readonly middleware: Middleware[]
   public readonly params?: RequestParams
   public readonly path: string | ((args: RequestParams) => string)
+  public readonly pathAttr: string
   public readonly queryParamAlias: Record<string, string>
   public readonly timeoutAttr: string
 
@@ -72,6 +75,7 @@ export class MethodDescriptor {
     this.bodyAttr = params.bodyAttr || 'body'
     this.headersAttr = params.headersAttr || 'headers'
     this.hostAttr = params.hostAttr || 'host'
+    this.pathAttr = params.pathAttr || 'path'
     this.timeoutAttr = params.timeoutAttr || 'timeout'
 
     const resourceMiddleware = params.middleware || params.middlewares || []

--- a/src/request.ts
+++ b/src/request.ts
@@ -48,7 +48,8 @@ export class Request {
       key !== this.methodDescriptor.bodyAttr &&
       key !== this.methodDescriptor.authAttr &&
       key !== this.methodDescriptor.timeoutAttr &&
-      key !== this.methodDescriptor.hostAttr
+      key !== this.methodDescriptor.hostAttr &&
+      key !== this.methodDescriptor.pathAttr
     )
   }
 
@@ -105,11 +106,13 @@ export class Request {
    *    '[Mappersmith] required parameter missing (name), "/some/{name}" cannot be resolved'
    */
   public path() {
+    const { pathAttr: mdPathAttr, path: mdPath } = this.methodDescriptor
+    const originalPath = (this.requestParams[mdPathAttr] as RequestParams['path']) || mdPath || ''
     const params = this.params()
 
-    let path
-    if (typeof this.methodDescriptor.path === 'function') {
-      path = this.methodDescriptor.path(params)
+    let path: string
+    if (typeof originalPath === 'function') {
+      path = originalPath(params)
       if (typeof path !== 'string') {
         throw new Error(
           `[Mappersmith] method descriptor function did not return a string, params=${JSON.stringify(
@@ -118,7 +121,7 @@ export class Request {
         )
       }
     } else {
-      path = this.methodDescriptor.path
+      path = originalPath
     }
 
     // RegExp with 'g'-flag is stateful, therefore defining it locally
@@ -260,6 +263,7 @@ export class Request {
     const headerKey = this.methodDescriptor.headersAttr
     const hostKey = this.methodDescriptor.hostAttr
     const timeoutKey = this.methodDescriptor.timeoutAttr
+    const pathKey = this.methodDescriptor.pathAttr
 
     // Note: The result of merging an instance of RequestParams with instance of Params
     // is simply a RequestParams with even more [param: string]'s on it.
@@ -273,6 +277,7 @@ export class Request {
     extras.body && (requestParams[bodyKey] = extras.body)
     extras.host && (requestParams[hostKey] = extras.host)
     extras.timeout && (requestParams[timeoutKey] = extras.timeout)
+    extras.path && (requestParams[pathKey] = extras.path)
 
     const nextContext = { ...this.requestContext, ...requestContext }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface RequestParams {
   readonly body?: Body
   readonly headers?: Headers
   readonly host?: string
+  readonly path?: string
   readonly params?: Params
   readonly timeout?: number
   [param: string]: object | Primitive | undefined | null | NestedParam | NestedParamArray


### PR DESCRIPTION
## Why
In a project we are looking at we are trying to create a dynamic mappersmith client we are relying on overriding `host` with `$hostname$path`:
```ts
const client = forge({
  clientId: name,
  host,  // https://api.ourdomain.com/dcom/financialoptions/configuration
  middleware: [...middleware, ...baseMiddleware],
  resources, // resources is a dummy that has path: ''
  allowResourceHostOverride: true,
}) as unknown as Resources;
```

There are two problems with this:
1) Mappersmith expects `host` to be only host. This is fine, but it also pushes the responsiblity of `/` between host and `path` to `path` when it is part of neither: https://www.rfc-editor.org/rfc/rfc1738#section-3.1 which is an internal mappersmith design decision that has worked out fine so far (even though it might not be 100% correct?)
2) We have query params. So in the end we might get `https://api.ourdomain.com/dcom/financialoptions/configuration/?market=SE&brand=VCC&language=sv-SE&customerType=b2c` where we would want `https://api.ourdomain.com/dcom/financialoptions/configuration?market=SE&brand=VCC&language=sv-SE&customerType=b2c` since the server might not handle the trailing slash

Diff to illustrate the point better:
```diff
> https://api.ourdomain.com/dcom/financialoptions/configuration/?market=SE&brand=VCC&language=sv-SE&customerType=b2c
< https://api.ourdomain.com/dcom/financialoptions/configuration?market=SE&brand=VCC&language=sv-SE&customerType=b2c`
```

If we were allowed to affect `path` in this way:
```ts
const client = forge({
  clientId: name,
  host, // https://gw.consumer.api.volvocars.com
  path, // dcom/financialoptions/configuration
  middleware: [...middleware, ...baseMiddleware],
  resources, 
  allowResourceHostOverride: true,
}) as unknown as Resources;
```

We wouldn't have this problem. Mappersmith can add `/` to path and get `/dcom/financialoptions/configuration` - as long as it doesn't add a trailing slash.

## Note
Note that this change is breaking for people that uses `client.Resource.method({ path: ... })` as it no longer counts as a request param. This means `path` no longer goes to query parameters or to path interpolation.

In order to get around this, those users could update their forge manifests to point to a different pathAttr such as:
```ts
import forge from 'mappersmith';

return forge({
  clientId: name,
  host,
  middleware: [...middleware, ...baseMiddleware],
  resources,
  pathAttr: '__path', // make 'path' a non-reserved attribute again
})
```