### PR TITLE
Allow Client invocations to specify RequestContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+Added:
+  - `mappersmith`: A forged client now optionally accepts request context as its second argument #330
+
 ## 2.41.0
 
 Fixed:

--- a/spec/typescript/basic.spec.ts
+++ b/spec/typescript/basic.spec.ts
@@ -24,3 +24,11 @@ const github = forge({
 github.Status.lastMessage({ randomParam: 10, another: { foo: 'hi' } }).then((response) => {
   console.log(`status: ${response.data()}`)
 })
+
+github.Status.lastMessage(
+  { randomParam: 10, another: { foo: 'hi' } },
+  { myContext: 'something ' }
+).then((response) => {
+  const context = response.originalRequest.context<{ myContext: string }>()
+  console.log({ myContext: context.myContext })
+})

--- a/src/client-builder.spec.ts
+++ b/src/client-builder.spec.ts
@@ -170,4 +170,22 @@ describe('ClientBuilder', () => {
       ).not.toThrowError()
     })
   })
+
+  describe('request context', () => {
+    it('allows specifying the context of a request', async () => {
+      const manifest = getManifest()
+      const clientBuilder = new ClientBuilder(manifest, GatewayClassFactory, configs)
+      const client = clientBuilder.build()
+      gatewayInstance.call.mockReturnValue(Promise.resolve('value'))
+      const response = await client.User.byId({ id: 1 }, { myContext: 'banana' })
+      expect(response).toEqual('value')
+      expect(gatewayClass).toHaveBeenCalledWith(expect.any(Request), configs.gatewayConfigs)
+      expect(gatewayInstance.call).toHaveBeenCalled()
+
+      const request: Request = gatewayClass.mock.calls[0][0]
+      expect(request).toBeInstanceOf(Request)
+      // For consumption within Middleware:
+      expect(request.context()).toEqual({ myContext: 'banana' })
+    })
+  })
 })

--- a/src/client-builder.ts
+++ b/src/client-builder.ts
@@ -6,12 +6,12 @@ import {
   ResourceTypeConstraint,
 } from './manifest'
 import { Response } from './response'
-import { Request } from './request'
+import { Request, RequestContext } from './request'
 import type { MiddlewareDescriptor, RequestGetter, ResponseGetter } from './middleware'
 import { Gateway } from './gateway'
 import type { Params } from './types'
 
-export type AsyncFunction = (params?: Params) => Promise<Response>
+export type AsyncFunction = (params?: Params, context?: RequestContext) => Promise<Response>
 
 export type AsyncFunctions<HashType> = {
   [Key in keyof HashType]: AsyncFunction
@@ -83,8 +83,8 @@ export class ClientBuilder<Resources extends ResourceTypeConstraint> {
     const initialResourceValue: Partial<Resource> = {}
 
     const resource = methods.reduce((resource, method) => {
-      const resourceMethod = (requestParams: Params) => {
-        const request = new Request(method.descriptor, requestParams)
+      const resourceMethod = (requestParams?: Params, context?: RequestContext) => {
+        const request = new Request(method.descriptor, requestParams, context)
         // `resourceName` can be `PropertyKey`, making this `string | number | Symbol`, therefore the string conversion
         // to stop type bleeding.
         return this.invokeMiddlewares(String(resourceName), method.name, request)

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -978,4 +978,44 @@ describe('Request', () => {
       })
     })
   })
+
+  describe('#context', () => {
+    const requestContext = {
+      myProp: 'myValue',
+    }
+
+    it('returns the specified context', async () => {
+      const request = new Request(methodDescriptor, requestParams, requestContext)
+      expect(request.context()).toEqual({
+        myProp: 'myValue',
+      })
+    })
+
+    describe('when enhancing a request', () => {
+      it('extends the specified context', async () => {
+        const extendedContext = {
+          myProp2: 'myValue2',
+        }
+        const request = new Request(methodDescriptor, requestParams, requestContext)
+        const enhanced = request.enhance({}, extendedContext)
+        expect(enhanced.context()).toEqual({
+          myProp: 'myValue',
+          myProp2: 'myValue2',
+        })
+      })
+
+      it('overrides any previously set values', async () => {
+        const extendedContext = {
+          myProp: 'myOverrideValue',
+          myProp2: 'myValue2',
+        }
+        const request = new Request(methodDescriptor, requestParams, requestContext)
+        const enhanced = request.enhance({}, extendedContext)
+        expect(enhanced.context()).toEqual({
+          myProp: 'myOverrideValue',
+          myProp2: 'myValue2',
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
Fixes #330 

Usage:
```ts
github.Status.lastMessage(
  { randomParam: 10, another: { foo: 'hi' } },
  { myContext: 'something ' }
).then((response) => {
  const context = response.originalRequest.context<{ myContext: string }>()
  console.log({ myContext: context.myContext })
})
```

The context is meant to be used for request/response middleware to carry information from one middleware to another, or in this case, from the caller to to the middleware.

Passing a context is optional, and doing so will **not** affect the final request that is sent over the wire in **any way**, so it is safe to start using it, and knowing it won't mutate any Gateway IO.