### PR TITLE
Add support for final request in response phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Added:
   - `mappersmith`: A forged client now optionally accepts request context as its second argument #330
+  - `mappersmith`: Add support for accessing the final request object in middleware response phase #321
 
 ## 2.41.0
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ __Mappersmith__ is a lightweight rest client for node.js and the browser. It cre
         - [mockRequest](#creating-middleware-optional-arguments-mock-request)
         - [Abort](#creating-middleware-optional-arguments-abort)
         - [Renew](#creating-middleware-optional-arguments-renew)
+        - [getFinalRequest](#creating-middleware-optional-arguments-getFinalRequest)
     - [Configuring middleware](#configuring-middleware)
       - [Resource level middleware](#resource-middleware)
       - [Client level middleware](#client-middleware)
@@ -603,6 +604,24 @@ configs.maxMiddlewareStackExecutionAllowed = 3
 ```
 
 If an infinite loop is detected, mappersmith will throw an error.
+
+##### <a name="creating-middleware-optional-arguments-getFinalRequest"></a> getFinalRequest
+
+The `response` phase can optionally receive a function called "getFinalRequest". This function can be used to get access to the final request object (after the whole middleware chain has prepared and all `prepareRequest` been executed). This feature is useful in some scenarios, for example, when you want to get access to the request object without invoking `next`:
+
+```javascript
+const CircuitBreakerMiddleware = () => {
+  return () => ({
+    response(next, renew, getFinalRequest) {
+      const request = getFinalRequest()
+      // Creating the breaker required some information available only on `request`:
+      const breaker = createBreaker({ ..., timeout: request.timeout })
+      // Note: `next` is still wrapped:
+      return breaker.invoke(createExecutor(next))
+    }
+  })
+}
+```
 
 ### <a name="configuring-middleware"></a> Configuring middleware
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ __Mappersmith__ is a lightweight rest client for node.js and the browser. It cre
         - [mockRequest](#creating-middleware-optional-arguments-mock-request)
         - [Abort](#creating-middleware-optional-arguments-abort)
         - [Renew](#creating-middleware-optional-arguments-renew)
-        - [getFinalRequest](#creating-middleware-optional-arguments-getFinalRequest)
+        - [request](#creating-middleware-optional-arguments-request)
     - [Configuring middleware](#configuring-middleware)
       - [Resource level middleware](#resource-middleware)
       - [Client level middleware](#client-middleware)
@@ -605,15 +605,14 @@ configs.maxMiddlewareStackExecutionAllowed = 3
 
 If an infinite loop is detected, mappersmith will throw an error.
 
-##### <a name="creating-middleware-optional-arguments-getFinalRequest"></a> getFinalRequest
+##### <a name="creating-middleware-optional-arguments-request"></a> request
 
-The `response` phase can optionally receive a function called "getFinalRequest". This function can be used to get access to the final request object (after the whole middleware chain has prepared and all `prepareRequest` been executed). This feature is useful in some scenarios, for example, when you want to get access to the request object without invoking `next`:
+The `response` phase can optionally receive an argument called "request". This argument is the final request (after the whole middleware chain has prepared and all `prepareRequest` been executed). This is useful in some scenarios, for example when you want to get access to the `request` without invoking `next`:
 
 ```javascript
 const CircuitBreakerMiddleware = () => {
   return () => ({
-    response(next, renew, getFinalRequest) {
-      const request = getFinalRequest()
+    response(next, renew, request) {
       // Creating the breaker required some information available only on `request`:
       const breaker = createBreaker({ ..., timeout: request.timeout })
       // Note: `next` is still wrapped:

--- a/spec/browser/middleware.spec.js
+++ b/spec/browser/middleware.spec.js
@@ -100,7 +100,11 @@ describe('ClientBuilder middleware', () => {
 
     await createClient().User.byId({ id: 1 })
     expect(requestPhase).toHaveBeenCalledWith(expect.any(Request))
-    expect(responsePhase).toHaveBeenCalledWith(expect.any(Function), expect.any(Function))
+    expect(responsePhase).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    )
   })
 
   it('calls request and response phase with a different "this" configured', async () => {
@@ -280,7 +284,11 @@ describe('ClientBuilder middleware', () => {
 
     await createClient().User.byId({ id: 1 })
     expect(prepareRequestPhase).toHaveBeenCalledWith(expect.any(Function), expect.any(Function))
-    expect(responsePhase).toHaveBeenCalledWith(expect.any(Function), expect.any(Function))
+    expect(responsePhase).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    )
   })
 
   describe('#prepareRequest', () => {

--- a/spec/browser/middleware.spec.js
+++ b/spec/browser/middleware.spec.js
@@ -103,7 +103,7 @@ describe('ClientBuilder middleware', () => {
     expect(responsePhase).toHaveBeenCalledWith(
       expect.any(Function),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Request)
     )
   })
 
@@ -287,7 +287,7 @@ describe('ClientBuilder middleware', () => {
     expect(responsePhase).toHaveBeenCalledWith(
       expect.any(Function),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Request)
     )
   })
 

--- a/spec/typescript/middleware.spec.ts
+++ b/spec/typescript/middleware.spec.ts
@@ -50,8 +50,8 @@ const MyMiddlewareReadingFinalRequest: Middleware = () => ({
     const request = await next()
     return request.enhance({}, { myFavoritePet: 'turtle' })
   },
-  async response(next, _renew, finalRequest) {
-    const context = finalRequest().context<{ myFavoritePet: string }>()
+  async response(next, _renew, request) {
+    const context = request.context<{ myFavoritePet: string }>()
 
     if (context.myFavoritePet === 'turtle') {
       console.log("Really? That's my favorite pet too!")
@@ -160,7 +160,7 @@ export const test = async () => {
     const response = await myMiddleware.response(
       async () => originalResponse,
       renewFn,
-      () => originalResponse.request()
+      originalResponse.request()
     )
     const data = response.data()
     // Right now these are different types

--- a/spec/typescript/middleware.spec.ts
+++ b/spec/typescript/middleware.spec.ts
@@ -142,7 +142,11 @@ export const test = async () => {
   if (myMiddleware.response) {
     const originalResponse = responseFactory({ data: { a: 1 } })
     const originalData = originalResponse.data()
-    const response = await myMiddleware.response(async () => originalResponse, renewFn)
+    const response = await myMiddleware.response(
+      async () => originalResponse,
+      renewFn,
+      () => originalResponse.request()
+    )
     const data = response.data()
     // Right now these are different types
     console.log({ originalData, data })

--- a/spec/typescript/middleware.spec.ts
+++ b/spec/typescript/middleware.spec.ts
@@ -1,22 +1,20 @@
-import forge from '../../src/mappersmith'
+import forge, { Response } from '../../src/mappersmith'
 import { Middleware, MiddlewareParams, RenewFn } from '../../src/middleware'
 import { responseFactory } from '../../src/test'
 
 const MyMiddleware: Middleware = () => ({
-  prepareRequest(next) {
-    return next().then((response) =>
-      response.enhance({
-        headers: { 'x-special-request': '->' },
-      })
-    )
+  async prepareRequest(next) {
+    const response = await next()
+    return response.enhance({
+      headers: { 'x-special-request': '->' },
+    })
   },
 
-  response(next) {
-    return next().then((response) =>
-      response.enhance({
-        headers: { 'x-special-response': '<-' },
-      })
-    )
+  async response(next) {
+    const response = await next()
+    return response.enhance({
+      headers: { 'x-special-response': '<-' },
+    })
   },
 })
 
@@ -31,38 +29,39 @@ const MyMiddlewareWithOptions: Middleware = ({
 }
 
 const MyMiddlewareWithSecondArgument: Middleware = () => ({
-  prepareRequest(next, abort) {
-    return next().then((request) =>
-      request.header('x-special') ? request : abort(new Error('"x-special" must be set!'))
-    )
+  async prepareRequest(next, abort) {
+    const request = await next()
+    return request.header('x-special') ? request : abort(new Error('"x-special" must be set!'))
   },
-  response(next, renew) {
-    return next().catch((response) => {
-      if (response.status() === 401) {
+  async response(next, renew) {
+    try {
+      return await next()
+    } catch (response) {
+      if (response instanceof Response && response.status() === 401) {
         return renew()
       }
-
-      return next()
-    })
+      return await next()
+    }
   },
 })
 
 const MyMiddlewareWithPrivateProperties: Middleware<{ foo: string }> = () => ({
-  prepareRequest(next, abort) {
-    return next().then((request) => {
-      // OK:
-      this.foo = 'bar'
-      // Also OK:
-      this['foo'] = 'baz'
-      // @ts-expect-error Not OK, not declared as PrivateProps:
-      this.bar = 'bar'
-      // @ts-expect-error Also not OK:
-      this['bar'] = 'baz'
-      return request.header('x-special') ? request : abort(new Error('"x-special" must be set!'))
-    })
+  async prepareRequest(next, abort) {
+    const request = await next()
+    // OK:
+    this.foo = 'bar'
+    // Also OK:
+    this['foo'] = 'baz'
+    // @ts-expect-error Not OK, not declared as PrivateProps:
+    this.bar = 'bar'
+    // @ts-expect-error Also not OK:
+    this['bar'] = 'baz'
+    return request.header('x-special') ? request : abort(new Error('"x-special" must be set!'))
   },
-  response(next, renew) {
-    return next().catch((response) => {
+  async response(next, renew) {
+    try {
+      return await next()
+    } catch (response) {
       const { foo } = this
 
       if (foo === undefined) {
@@ -71,38 +70,37 @@ const MyMiddlewareWithPrivateProperties: Middleware<{ foo: string }> = () => ({
 
       console.log(foo)
 
-      if (response.status() === 401) {
+      if (response instanceof Response && response.status() === 401) {
         return renew()
       }
-
-      return next()
-    })
+      return await next()
+    }
   },
 })
 
 const MyMiddlewareWithPrivateProperties2: Middleware = () => ({
-  prepareRequest(next, abort) {
-    return next().then((request) => {
-      // @ts-expect-error Not OK, not declared as PrivateProps:
-      this.foo = 'bar'
-      // @ts-expect-error Also not OK:
-      this['foo'] = 'baz'
-      return request.header('x-special') ? request : abort(new Error('"x-special" must be set!'))
-    })
+  async prepareRequest(next, abort) {
+    const request = await next()
+    // @ts-expect-error Not OK, not declared as PrivateProps:
+    this.foo = 'bar'
+    // @ts-expect-error Also not OK:
+    this['foo'] = 'baz'
+    return request.header('x-special') ? request : abort(new Error('"x-special" must be set!'))
   },
-  response(next, renew) {
-    return next().catch((response) => {
+  async response(next, renew) {
+    try {
+      return await next()
+    } catch (response) {
       // @ts-expect-error Not OK, doesn't exist:
       const { foo } = this
 
       console.log(foo)
 
-      if (response.status() === 401) {
+      if (response instanceof Response && response.status() === 401) {
         return renew()
       }
-
-      return next()
-    })
+      return await next()
+    }
   },
 })
 

--- a/spec/typescript/middleware.spec.ts
+++ b/spec/typescript/middleware.spec.ts
@@ -45,6 +45,22 @@ const MyMiddlewareWithSecondArgument: Middleware = () => ({
   },
 })
 
+const MyMiddlewareReadingFinalRequest: Middleware = () => ({
+  async prepareRequest(next) {
+    const request = await next()
+    return request.enhance({}, { myFavoritePet: 'turtle' })
+  },
+  async response(next, _renew, finalRequest) {
+    const context = finalRequest().context<{ myFavoritePet: string }>()
+
+    if (context.myFavoritePet === 'turtle') {
+      console.log("Really? That's my favorite pet too!")
+    }
+
+    return await next()
+  },
+})
+
 const MyMiddlewareWithPrivateProperties: Middleware<{ foo: string }> = () => ({
   async prepareRequest(next, abort) {
     const request = await next()
@@ -113,6 +129,7 @@ const github = forge({
     MyMiddlewareWithSecondArgument,
     MyMiddlewareWithPrivateProperties,
     MyMiddlewareWithPrivateProperties2,
+    MyMiddlewareReadingFinalRequest,
   ],
   resources: {
     Status: {

--- a/src/client-builder.ts
+++ b/src/client-builder.ts
@@ -175,8 +175,9 @@ export class ClientBuilder<Resources extends ResourceTypeConstraint> {
           const renew = executeMiddlewareStack
           const chainResponsePhase =
             (previousValue: ResponseGetter, currentValue: MiddlewareDescriptor) => () => {
+              const getFinalRequest = () => finalRequest
               // Deliberately putting this on two separate lines - to get typescript to not return "any"
-              const nextValue = currentValue.response(previousValue, renew)
+              const nextValue = currentValue.response(previousValue, renew, getFinalRequest)
               return nextValue
             }
           const callGateway = () => new GatewayClass(finalRequest, gatewayConfigs).call()

--- a/src/client-builder.ts
+++ b/src/client-builder.ts
@@ -175,9 +175,8 @@ export class ClientBuilder<Resources extends ResourceTypeConstraint> {
           const renew = executeMiddlewareStack
           const chainResponsePhase =
             (previousValue: ResponseGetter, currentValue: MiddlewareDescriptor) => () => {
-              const getFinalRequest = () => finalRequest
               // Deliberately putting this on two separate lines - to get typescript to not return "any"
-              const nextValue = currentValue.response(previousValue, renew, getFinalRequest)
+              const nextValue = currentValue.response(previousValue, renew, finalRequest)
               return nextValue
             }
           const callGateway = () => new GatewayClass(finalRequest, gatewayConfigs).call()

--- a/src/middleware/duration.spec.ts
+++ b/src/middleware/duration.spec.ts
@@ -33,7 +33,7 @@ describe('Middleware / DurationMiddleware', () => {
     const finalResponse = await middleware.response?.(
       () => Promise.resolve(response),
       () => Promise.resolve(response),
-      () => finalRequest
+      finalRequest
     )
     const startedAt = finalResponse?.header('x-started-at')
     const endedAt = finalResponse?.header('x-ended-at')
@@ -55,7 +55,7 @@ describe('Middleware / DurationMiddleware', () => {
     const finalResponse = await middleware.response?.(
       () => Promise.resolve(response),
       () => Promise.resolve(response),
-      () => finalRequest
+      finalRequest
     )
     const data = finalResponse?.data()
     expect(data).toEqual('')

--- a/src/middleware/duration.spec.ts
+++ b/src/middleware/duration.spec.ts
@@ -32,7 +32,8 @@ describe('Middleware / DurationMiddleware', () => {
 
     const finalResponse = await middleware.response?.(
       () => Promise.resolve(response),
-      () => Promise.resolve(response)
+      () => Promise.resolve(response),
+      () => finalRequest
     )
     const startedAt = finalResponse?.header('x-started-at')
     const endedAt = finalResponse?.header('x-ended-at')
@@ -53,7 +54,8 @@ describe('Middleware / DurationMiddleware', () => {
 
     const finalResponse = await middleware.response?.(
       () => Promise.resolve(response),
-      () => Promise.resolve(response)
+      () => Promise.resolve(response),
+      () => finalRequest
     )
     const data = finalResponse?.data()
     expect(data).toEqual('')

--- a/src/middleware/global-error-handler.spec.ts
+++ b/src/middleware/global-error-handler.spec.ts
@@ -27,7 +27,7 @@ describe('Middleware / GlobalErrorHandlerMiddleware', () => {
         .response?.(
           () => Promise.resolve(originalResponse),
           () => Promise.resolve(originalResponse),
-          () => originalResponse.request()
+          originalResponse.request()
         )
         .then((response) => {
           expect(response).toEqual(originalResponse)
@@ -46,7 +46,7 @@ describe('Middleware / GlobalErrorHandlerMiddleware', () => {
         .response?.(
           () => Promise.reject(originalResponse),
           () => Promise.resolve(originalResponse),
-          () => originalResponse.request()
+          originalResponse.request()
         )
         .then((response) => {
           done.fail(`Expected this promise to fail: ${response}`)
@@ -74,7 +74,7 @@ describe('Middleware / GlobalErrorHandlerMiddleware', () => {
         .response?.(
           () => Promise.reject(originalResponse),
           () => Promise.resolve(originalResponse),
-          () => originalResponse.request()
+          originalResponse.request()
         )
         .then((response) => {
           done.fail(`Expected this promise to fail: ${response}`)

--- a/src/middleware/global-error-handler.spec.ts
+++ b/src/middleware/global-error-handler.spec.ts
@@ -26,10 +26,11 @@ describe('Middleware / GlobalErrorHandlerMiddleware', () => {
       middleware
         .response?.(
           () => Promise.resolve(originalResponse),
-          () => Promise.resolve(originalResponse)
+          () => Promise.resolve(originalResponse),
+          () => originalResponse.request()
         )
         .then((response) => {
-          expect(response).toEqual(response)
+          expect(response).toEqual(originalResponse)
           done()
         })
     })
@@ -44,7 +45,8 @@ describe('Middleware / GlobalErrorHandlerMiddleware', () => {
       middleware
         .response?.(
           () => Promise.reject(originalResponse),
-          () => Promise.resolve(originalResponse)
+          () => Promise.resolve(originalResponse),
+          () => originalResponse.request()
         )
         .then((response) => {
           done.fail(`Expected this promise to fail: ${response}`)
@@ -71,7 +73,8 @@ describe('Middleware / GlobalErrorHandlerMiddleware', () => {
       middleware
         .response?.(
           () => Promise.reject(originalResponse),
-          () => Promise.resolve(originalResponse)
+          () => Promise.resolve(originalResponse),
+          () => originalResponse.request()
         )
         .then((response) => {
           done.fail(`Expected this promise to fail: ${response}`)

--- a/src/middleware/index.spec.ts
+++ b/src/middleware/index.spec.ts
@@ -1,90 +1,141 @@
 import forge from '../index'
 import { Middleware } from 'middleware'
-import { install, uninstall, mockRequest } from '../test'
+import { install, uninstall, mockRequest, m } from '../test'
 
-describe('integration', () => {
+describe('middleware', () => {
   beforeAll(install)
   afterAll(uninstall)
+  const host = 'http://example.org'
+  const path = '/api/test'
 
-  describe('middleware', () => {
-    describe('prepareRequest', () => {
-      const host = 'http://example.org'
-      const path = '/api/test'
+  describe('prepareRequest', () => {
+    beforeEach(() => {
+      mockRequest({
+        method: 'get',
+        url: `${host}${path}`,
+        body: undefined,
+        headers: {},
+        response: {
+          body: { ok: true },
+          status: 200,
+        },
+      })
+    })
 
-      beforeEach(() => {
-        mockRequest({
-          method: 'get',
-          url: `${host}${path}`,
-          body: undefined,
-          headers: {},
-          response: {
-            body: { ok: true },
-            status: 200,
-          },
-        })
+    const createContextMiddleware =
+      (spy: jest.Mock, context: Record<string, unknown>): Middleware =>
+      () => ({
+        prepareRequest: async (next) => {
+          const request = await next()
+          const contextBefore = request.context()
+          spy(contextBefore)
+
+          const newRequest = request.enhance({}, context)
+          const contextAfter = newRequest.context()
+          spy(contextAfter)
+
+          return newRequest
+        },
       })
 
-      const createContextMiddleware =
-        (spy: jest.Mock, context: Record<string, unknown>): Middleware =>
-        () => ({
-          prepareRequest: async (next) => {
-            const request = await next()
-            const contextBefore = request.context()
-            spy(contextBefore)
+    it('invokes middleware and extends request context in given order', async () => {
+      const spy = jest.fn()
+      const mw1 = createContextMiddleware(spy, { foo: 'bar' })
+      const mw2 = createContextMiddleware(spy, { ctx: 'yup' })
+      const mw3 = createContextMiddleware(spy, { ctx: 'bts' })
+      const client = forge({
+        clientId: 'testMw',
+        middleware: [mw1, mw2, mw3],
+        host,
+        resources: { Resource: { find: { path } } },
+      })
+      await client.Resource.find()
+      // mw1 applied
+      expect(spy).toHaveBeenNthCalledWith(1, {})
+      expect(spy).toHaveBeenNthCalledWith(2, { foo: 'bar' })
+      // mw2 applied
+      expect(spy).toHaveBeenNthCalledWith(3, { foo: 'bar' })
+      expect(spy).toHaveBeenNthCalledWith(4, { ctx: 'yup', foo: 'bar' })
+      // mw3 applied
+      expect(spy).toHaveBeenNthCalledWith(5, { ctx: 'yup', foo: 'bar' })
+      expect(spy).toHaveBeenNthCalledWith(6, { ctx: 'bts', foo: 'bar' })
+    })
 
-            const newRequest = request.enhance({}, context)
-            const contextAfter = newRequest.context()
-            spy(contextAfter)
+    it('invokes resource specific middleware first', async () => {
+      const spy = jest.fn()
+      const mw1 = createContextMiddleware(spy, { foo: 'bar' })
+      const mw2 = createContextMiddleware(spy, { ctx: 'yup' })
+      const mw3 = createContextMiddleware(spy, { ctx: 'bts' })
+      const client = forge({
+        clientId: 'testMw',
+        middleware: [mw1, mw3],
+        host,
+        resources: { Resource: { find: { path, middleware: [mw2] } } },
+      })
+      await client.Resource.find()
+      // mw2 applied
+      expect(spy).toHaveBeenNthCalledWith(1, {})
+      expect(spy).toHaveBeenNthCalledWith(2, { ctx: 'yup' })
+      // mw1 applied
+      expect(spy).toHaveBeenNthCalledWith(3, { ctx: 'yup' })
+      expect(spy).toHaveBeenNthCalledWith(4, { ctx: 'yup', foo: 'bar' })
+      // mw3 applied
+      expect(spy).toHaveBeenNthCalledWith(5, { ctx: 'yup', foo: 'bar' })
+      expect(spy).toHaveBeenNthCalledWith(6, { ctx: 'bts', foo: 'bar' })
+    })
+  })
 
-            return newRequest
-          },
-        })
+  describe('response', () => {
+    beforeEach(() => {
+      mockRequest({
+        method: 'post',
+        url: `${host}${path}`,
+        body: m.anything(),
+        headers: {},
+        response: {
+          body: { ok: true },
+          status: 200,
+        },
+      })
+    })
 
-      it('invokes middleware and extends request context in given order', async () => {
-        const spy = jest.fn()
-        const mw1 = createContextMiddleware(spy, { foo: 'bar' })
-        const mw2 = createContextMiddleware(spy, { ctx: 'yup' })
-        const mw3 = createContextMiddleware(spy, { ctx: 'bts' })
-        const client = forge({
-          clientId: 'testMw',
-          middleware: [mw1, mw2, mw3],
-          host,
-          resources: { Resource: { find: { path } } },
-        })
-        await client.Resource.find()
-        // mw1 applied
-        expect(spy).toHaveBeenNthCalledWith(1, {})
-        expect(spy).toHaveBeenNthCalledWith(2, { foo: 'bar' })
-        // mw2 applied
-        expect(spy).toHaveBeenNthCalledWith(3, { foo: 'bar' })
-        expect(spy).toHaveBeenNthCalledWith(4, { ctx: 'yup', foo: 'bar' })
-        // mw3 applied
-        expect(spy).toHaveBeenNthCalledWith(5, { ctx: 'yup', foo: 'bar' })
-        expect(spy).toHaveBeenNthCalledWith(6, { ctx: 'bts', foo: 'bar' })
+    const createMiddleware =
+      (spy: jest.Mock, params: Record<string, string>): Middleware =>
+      () => ({
+        prepareRequest: async (next) => {
+          const request = await next()
+          return request.enhance({}, params)
+        },
+        response: async (next, _renew, getFinalRequest) => {
+          const context = getFinalRequest().context()
+          spy(params)
+          spy(context)
+          const response = await next()
+          return response
+        },
       })
 
-      it('invokes resource specific middleware first', async () => {
-        const spy = jest.fn()
-        const mw1 = createContextMiddleware(spy, { foo: 'bar' })
-        const mw2 = createContextMiddleware(spy, { ctx: 'yup' })
-        const mw3 = createContextMiddleware(spy, { ctx: 'bts' })
-        const client = forge({
-          clientId: 'testMw',
-          middleware: [mw1, mw3],
-          host,
-          resources: { Resource: { find: { path, middleware: [mw2] } } },
-        })
-        await client.Resource.find()
-        // mw2 applied
-        expect(spy).toHaveBeenNthCalledWith(1, {})
-        expect(spy).toHaveBeenNthCalledWith(2, { ctx: 'yup' })
-        // mw1 applied
-        expect(spy).toHaveBeenNthCalledWith(3, { ctx: 'yup' })
-        expect(spy).toHaveBeenNthCalledWith(4, { ctx: 'yup', foo: 'bar' })
-        // mw3 applied
-        expect(spy).toHaveBeenNthCalledWith(5, { ctx: 'yup', foo: 'bar' })
-        expect(spy).toHaveBeenNthCalledWith(6, { ctx: 'bts', foo: 'bar' })
+    it('invokes middleware and extends response context in given order', async () => {
+      const spy = jest.fn()
+      const mw1 = createMiddleware(spy, { foo: 'mw1' })
+      const mw2 = createMiddleware(spy, { ctx: 'mw2' })
+      const mw3 = createMiddleware(spy, { ctx: 'mw3' })
+      const client = forge({
+        clientId: 'testMw',
+        middleware: [mw1, mw2, mw3],
+        host,
+        resources: { Resource: { create: { method: 'post', path } } },
       })
+      await client.Resource.create()
+      // mw3 applied
+      expect(spy).toHaveBeenNthCalledWith(1, { ctx: 'mw3' })
+      expect(spy).toHaveBeenNthCalledWith(2, { foo: 'mw1', ctx: 'mw3' })
+      // mw2 applied
+      expect(spy).toHaveBeenNthCalledWith(3, { ctx: 'mw2' })
+      expect(spy).toHaveBeenNthCalledWith(4, { foo: 'mw1', ctx: 'mw3' })
+      // mw1 applied
+      expect(spy).toHaveBeenNthCalledWith(5, { foo: 'mw1' })
+      expect(spy).toHaveBeenNthCalledWith(6, { foo: 'mw1', ctx: 'mw3' })
     })
   })
 })

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -49,11 +49,11 @@ export interface MiddlewareDescriptor {
      */
     renew: RenewFn,
     /**
-     * Function that returns the final request object (after the whole middleware chain has prepared and all `prepareRequest` been executed).
+     * The final request object (after the whole middleware chain has prepared and all `prepareRequest` been executed).
      *
-     * Useful for example when you want to get access to the request object without invoking `next`
+     * Useful for example when you want to get access to the request without invoking `next`
      */
-    getFinalRequest: () => Request
+    request: Request
   ): Promise<Response>
 }
 

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -18,11 +18,43 @@ export interface MiddlewareDescriptor {
    */
   request?(request: Request): Promise<Request> | Request
   /**
-   * @since 2.27.0
-   * Replaced the request method
+   * Allows a middleware to tap into the prepare request phase
    */
-  prepareRequest(next: RequestGetter, abort: AbortFn): Promise<Request | void>
-  response(next: ResponseGetter, renew: RenewFn, getFinalRequest: () => Request): Promise<Response>
+  prepareRequest(
+    /**
+     * This function must return a `Promise` resolving the `Request`.
+     *
+     * The method `enhance` can be used to generate a new request based on the previous one.
+     */
+    next: RequestGetter,
+    /**
+     * Function that can be used to abort the middleware execution early on and throw a custom error to the user.
+     */
+    abort: AbortFn
+  ): Promise<Request | void>
+  /**
+   * Allows a middleware to tap into the response phase
+   */
+  response(
+    /**
+     * This function must return a `Promise` resolving the `Response`.
+     *
+     * The method `enhance` can be used to generate a new response based on the previous one.
+     */
+    next: ResponseGetter,
+    /**
+     * Function that is used to rerun the middleware stack.
+     *
+     * Useful for example when automatically refreshing an expired access token.
+     */
+    renew: RenewFn,
+    /**
+     * Function that returns the final request object (after the whole middleware chain has prepared and all `prepareRequest` been executed).
+     *
+     * Useful for example when you want to get access to the request object without invoking `next`
+     */
+    getFinalRequest: () => Request
+  ): Promise<Response>
 }
 
 export interface MiddlewareParams {

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -22,7 +22,7 @@ export interface MiddlewareDescriptor {
    * Replaced the request method
    */
   prepareRequest(next: RequestGetter, abort: AbortFn): Promise<Request | void>
-  response(next: ResponseGetter, renew: RenewFn): Promise<Response>
+  response(next: ResponseGetter, renew: RenewFn, getFinalRequest: () => Request): Promise<Response>
 }
 
 export interface MiddlewareParams {


### PR DESCRIPTION
Fixes #321 

Usage:
```ts
  return function MyMiddleware() {
    return {
      async response(next, _, request) {
        // Access the final request object without invoking `await next()`:
        const context = request.context<{ host: string }>();
```