### PR TITLE
[V3] `Request.prototype.body` now respects `content-type` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Removed:
 - `@mappersmith/core`: Remove `middlewares` alias; use `middleware` instead.
 
 Changed:
+- `@mappersmith/core`: `Request.prototype.body` now respects `content-type` header and returns a JSON parsed result if the `content-type` is in the `+json` family. If you want the raw body without transformation, use `Request.prototype.rawBody` instead.
 - `@mappersmith/core`: No longer accepts `Promise` configuration, instead relying on native  Promise implementation to be available.
 - `@mappersmith/core`: Stop using `window.btoa` and use internal implementation instead.
 - `@mappersmith/*`: The project no longer produces a web artefact.

--- a/packages/core/src/gateway.ts
+++ b/packages/core/src/gateway.ts
@@ -94,7 +94,7 @@ export class Gateway {
   }
 
   prepareBody(method: string, headers: Record<string, Primitive>) {
-    let body = this.request.body()
+    let body = this.request.rawBody()
 
     if (this.shouldEmulateHTTP()) {
       body = body || {}

--- a/packages/core/src/middleware/basic-auth.spec.ts
+++ b/packages/core/src/middleware/basic-auth.spec.ts
@@ -5,7 +5,7 @@ import type { Auth } from '../types'
 
 const abort: AbortFn = () => ({})
 
-describe('Middleware / BasicAuth', () => {
+describe('BasicAuthMiddleware', () => {
   let middleware: Partial<MiddlewareDescriptor>
   const params: MiddlewareParams = {
     clientId: 'testClient',

--- a/packages/core/src/middleware/csrf.web.spec.ts
+++ b/packages/core/src/middleware/csrf.web.spec.ts
@@ -4,7 +4,7 @@ import { requestFactory } from '@mappersmith/test'
 
 const abort: AbortFn = () => ({})
 
-describe('Middleware / CSRF', () => {
+describe('CsrfMiddleware', () => {
   let middleware: Partial<MiddlewareDescriptor>
   const params: MiddlewareParams = {
     clientId: 'testClient',

--- a/packages/core/src/middleware/duration.spec.ts
+++ b/packages/core/src/middleware/duration.spec.ts
@@ -4,7 +4,7 @@ import { requestFactory, responseFactory } from '@mappersmith/test'
 
 const abort: AbortFn = () => ({})
 
-describe('Middleware / DurationMiddleware', () => {
+describe('DurationMiddleware', () => {
   let middleware: Partial<MiddlewareDescriptor>
   const params: MiddlewareParams = {
     clientId: 'testClient',

--- a/packages/core/src/middleware/encode-json.spec.ts
+++ b/packages/core/src/middleware/encode-json.spec.ts
@@ -5,7 +5,7 @@ import { requestFactory } from '@mappersmith/test'
 
 const abort: AbortFn = () => ({})
 
-describe('Middleware / EncodeJson', () => {
+describe('EncodeJsonMiddleware', () => {
   let middleware: Partial<MiddlewareDescriptor>
   const params: MiddlewareParams = {
     clientId: 'testClient',
@@ -23,10 +23,12 @@ describe('Middleware / EncodeJson', () => {
     expect(EncodeJsonMiddleware.name).toEqual('EncodeJsonMiddleware')
   })
 
-  it('stringify the body and add "content-type" application/json', async () => {
+  it('stringifies the body and adds "content-type" application/json', async () => {
     const request = requestFactory({ host: 'example.com', path: '/', method: 'get', body })
+
     const newRequest = await middleware.prepareRequest?.(() => Promise.resolve(request), abort)
-    expect(newRequest?.body()).toEqual(JSON.stringify(body))
+    expect(newRequest?.requestParams['body']).toEqual(JSON.stringify(body))
+    expect(newRequest?.body()).toEqual(body)
     expect(newRequest?.headers()['content-type']).toEqual(CONTENT_TYPE_JSON)
   })
 
@@ -103,7 +105,8 @@ describe('Middleware / EncodeJson', () => {
             () => Promise.resolve(request),
             abort
           )
-          expect(newRequest?.body()).toEqual(body)
+          expect(newRequest?.requestParams['body']).toEqual(body)
+          expect(newRequest?.body()).toEqual({ foo: 'bar' })
           expect(newRequest?.headers()).toEqual(headers)
         })
       })
@@ -125,7 +128,8 @@ describe('Middleware / EncodeJson', () => {
             () => Promise.resolve(request),
             abort
           )
-          expect(newRequest?.body()).toEqual(JSON.stringify(body))
+          expect(newRequest?.requestParams['body']).toEqual(JSON.stringify(body))
+          expect(newRequest?.body()).toEqual(body)
           expect(newRequest?.headers()).toEqual(headers)
         })
       })

--- a/packages/core/src/middleware/encode-json.ts
+++ b/packages/core/src/middleware/encode-json.ts
@@ -22,7 +22,7 @@ export const EncodeJsonMiddleware = (): Middleware =>
       async prepareRequest(next) {
         const request = await next()
         try {
-          const body = request.body()
+          const body = request.rawBody()
           const contentType = request.header('content-type')
 
           if (body) {

--- a/packages/core/src/middleware/global-error-handler.spec.ts
+++ b/packages/core/src/middleware/global-error-handler.spec.ts
@@ -2,7 +2,7 @@ import { GlobalErrorHandlerMiddleware, setErrorHandler } from './global-error-ha
 import type { MiddlewareDescriptor, MiddlewareParams } from './index'
 import { responseFactory } from '@mappersmith/test'
 
-describe('Middleware / GlobalErrorHandlerMiddleware', () => {
+describe('GlobalErrorHandlerMiddleware', () => {
   let middleware: Partial<MiddlewareDescriptor>
   const params: MiddlewareParams = {
     clientId: 'testClient',

--- a/packages/core/src/middleware/retry.web.spec.ts
+++ b/packages/core/src/middleware/retry.web.spec.ts
@@ -100,7 +100,7 @@ function retryMiddlewareExamples(
   })
 }
 
-describe('Middleware / RetryMiddleware', () => {
+describe('RetryMiddleware', () => {
   const retries = 3
   const headerRetryCount = 'X-Mappersmith-Retry-Count'
   const headerRetryTime = 'X-Mappersmith-Retry-Time'

--- a/packages/core/src/middleware/timeout.spec.ts
+++ b/packages/core/src/middleware/timeout.spec.ts
@@ -4,7 +4,7 @@ import { requestFactory } from '@mappersmith/test'
 
 const abort: AbortFn = () => ({})
 
-describe('Middleware / Timeout', () => {
+describe('TimeoutMiddleware', () => {
   let middleware: Partial<MiddlewareDescriptor>
   const params: MiddlewareParams = {
     clientId: 'testClient',

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -13,6 +13,7 @@ import type {
 const REGEXP_DYNAMIC_SEGMENT = /{([^}?]+)\??}/
 const REGEXP_OPTIONAL_DYNAMIC_SEGMENT = /\/?{([^}?]+)\?}/g
 const REGEXP_TRAILING_SLASH = /\/$/
+const REGEXP_CONTENT_TYPE_JSON = /^application\/(json|.*\+json)/
 
 export type RequestContext = Record<string, unknown>
 
@@ -234,8 +235,25 @@ export class Request {
     return undefined
   }
 
-  public body() {
+  /**
+   * Returns the original request body
+   */
+  public rawBody() {
     return this.requestParams[this.methodDescriptor.bodyAttr] as Body
+  }
+
+  /**
+   * Returns the request body
+   */
+  public body() {
+    const rawBody = this.rawBody()
+    const contentType = this.header<string>('content-type')
+    if (contentType && typeof rawBody === 'string' && REGEXP_CONTENT_TYPE_JSON.test(contentType)) {
+      try {
+        return JSON.parse(rawBody)
+      } catch (e) {} // eslint-disable-line no-empty
+    }
+    return rawBody
   }
 
   public auth() {

--- a/packages/test/src/index.js
+++ b/packages/test/src/index.js
@@ -161,7 +161,7 @@ export const m = {
 
 const requestToLog = (request) =>
   `"${request.method().toUpperCase()} ${request.url()}" (body: "${toQueryString(
-    request.body()
+    request.rawBody()
   )}"; headers: "${toQueryString(request.headers())}")`
 const mockToLog = (requestMock) =>
   `"${requestMock.method.toUpperCase()} ${requestMock.url}" (body: "${

--- a/packages/test/src/mocks/mock-request.js
+++ b/packages/test/src/mocks/mock-request.js
@@ -90,8 +90,8 @@ MockRequest.prototype = {
       }
 
       return this.bodyFunction
-        ? this.body(request.body())
-        : this.body === toSortedQueryString(request.body())
+        ? this.body(request.rawBody())
+        : this.body === toSortedQueryString(request.rawBody())
     }
 
     const urlMatch = this.urlFunction

--- a/packages/test/src/mocks/mock-resource.js
+++ b/packages/test/src/mocks/mock-resource.js
@@ -116,7 +116,7 @@ MockResource.prototype = {
       this.mockRequest = new MockRequest(this.id, {
         method: finalRequest.method(),
         url: this.generateUrlMatcher(finalRequest),
-        body: finalRequest.body(),
+        body: finalRequest.rawBody(),
         headers: finalRequest.headers(),
         response: {
           status: responseStatus,
@@ -160,7 +160,7 @@ MockResource.prototype = {
       if (this.mockRequest) {
         const urlMatcher = this.generateUrlMatcher(finalRequest)
         this.mockRequest.url = urlMatcher
-        this.mockRequest.body = finalRequest.body()
+        this.mockRequest.body = finalRequest.rawBody()
         this.pendingMiddlewareExecution = false
       }
     })


### PR DESCRIPTION
`Request.prototype.body` now respects `content-type` header and returns a JSON parsed result if the `content-type` is in the `+json` family. If you want the raw body without transformation, use `Request.prototype.rawBody` instead.

Fixes #343