### PR TITLE
Fix: memory leak with when using Http(s)Agent keepAlive=true

### DIFF
--- a/.changeset/friendly-bottles-unite.md
+++ b/.changeset/friendly-bottles-unite.md
@@ -1,0 +1,5 @@
+---
+'mappersmith': minor
+---
+
+Fixes memory leak when using http(s) agent with keep-alive

--- a/spec/integration/node/integration.spec.js
+++ b/spec/integration/node/integration.spec.js
@@ -96,6 +96,15 @@ describe('integration', () => {
             done.fail(`test failed with promise error: ${errorMessage(response)}`)
           })
         })
+
+        it('calls the `onRequestSocketAssigned` callback on every request', (done) => {
+          keepAliveHelper.callApiTwice().then(() => {
+            expect(gatewayConfigs.onRequestSocketAssigned).toHaveBeenCalledTimes(2)
+            done()
+          }).catch((response) => {
+            done.fail(`test failed with promise error: ${errorMessage(response)}`)
+          })
+        })
       })
 
       describe('with keep alive', () => {
@@ -110,6 +119,15 @@ describe('integration', () => {
           keepAliveHelper.callApiTwice().then(() => {
             keepAliveHelper.verifySockets(0, httpAgent.sockets)
             keepAliveHelper.verifySockets(1, httpAgent.freeSockets)
+            done()
+          }).catch((response) => {
+            done.fail(`test failed with promise error: ${errorMessage(response)}`)
+          })
+        })
+
+        it('calls the `onRequestSocketAssigned` callback on every request', (done) => {
+          keepAliveHelper.callApiTwice().then(() => {
+            expect(gatewayConfigs.onRequestSocketAssigned).toHaveBeenCalledTimes(2)
             done()
           }).catch((response) => {
             done.fail(`test failed with promise error: ${errorMessage(response)}`)

--- a/spec/integration/node/integration.spec.js
+++ b/spec/integration/node/integration.spec.js
@@ -92,6 +92,8 @@ describe('integration', () => {
             keepAliveHelper.verifySockets(1, httpAgent.sockets)
             keepAliveHelper.verifySockets(0, httpAgent.freeSockets)
             done()
+          }).catch((response) => {
+            done.fail(`test failed with promise error: ${errorMessage(response)}`)
           })
         })
       })
@@ -109,6 +111,8 @@ describe('integration', () => {
             keepAliveHelper.verifySockets(0, httpAgent.sockets)
             keepAliveHelper.verifySockets(1, httpAgent.freeSockets)
             done()
+          }).catch((response) => {
+            done.fail(`test failed with promise error: ${errorMessage(response)}`)
           })
         })
       })

--- a/spec/integration/node/support/keep-alive.js
+++ b/spec/integration/node/support/keep-alive.js
@@ -1,0 +1,21 @@
+import createManifest from 'spec/integration/support/manifest'
+
+import forge, { configs } from 'src/index'
+
+export default function keepAlive(host, gateway) {
+  return {
+    verifySockets: (socketsReference) => {
+      const socketOrigins = Object.keys(socketsReference)
+      expect(socketOrigins.length).toBe(1)
+      const sockets = socketsReference[socketOrigins[0]]
+      expect(sockets.length).toBe(1)
+      const socket = sockets[0]
+      expect(socket.listenerCount('lookup')).toBe(1)
+      expect(socket.listenerCount('connect')).toBe(1)
+    },
+    callApiTwice: () => {
+      const Client = forge(createManifest(host), gateway)
+      return Client.Book.all().then(() => Client.Book.all())
+    }
+  }
+}

--- a/spec/integration/node/support/keep-alive.js
+++ b/spec/integration/node/support/keep-alive.js
@@ -4,14 +4,16 @@ import forge from 'src/index'
 
 export default function keepAlive(host, gateway) {
   return {
-    verifySockets: (socketsReference) => {
+    verifySockets: (count, socketsReference) => {
       const socketOrigins = Object.keys(socketsReference)
-      expect(socketOrigins.length).toBe(1)
+      expect(socketOrigins.length).toBe(count)
+      if (count === 0) return
+
       const sockets = socketsReference[socketOrigins[0]]
-      expect(sockets.length).toBe(1)
+      expect(sockets.length).toBe(count)
       const socket = sockets[0]
-      expect(socket.listenerCount('lookup')).toBe(1)
-      expect(socket.listenerCount('connect')).toBe(1)
+      expect(socket.listenerCount('lookup')).toBe(count)
+      expect(socket.listenerCount('connect')).toBe(count)
     },
     callApiTwice: () => {
       const Client = forge(createManifest(host), gateway)

--- a/spec/integration/node/support/keep-alive.js
+++ b/spec/integration/node/support/keep-alive.js
@@ -1,6 +1,6 @@
 import createManifest from 'spec/integration/support/manifest'
 
-import forge, { configs } from 'src/index'
+import forge from 'src/index'
 
 export default function keepAlive(host, gateway) {
   return {

--- a/src/gateway/http.ts
+++ b/src/gateway/http.ts
@@ -1,7 +1,6 @@
 import * as url from 'url'
 import * as http from 'http'
 import * as https from 'https'
-import { Socket } from 'net'
 
 import { assign } from '../utils/index'
 import { Gateway } from './gateway'
@@ -101,9 +100,21 @@ export class HTTP extends Gateway {
         return
       }
 
-      this.assignSocketListener(socket, 'lookup', httpOptions.onSocketLookup?.bind(null, requestParams))
-      this.assignSocketListener(socket, 'connect', httpOptions.onSocketConnect?.bind(null, requestParams))
-      this.assignSocketListener(socket, 'secureConnect', httpOptions.onSocketSecureConnect?.bind(null, requestParams))
+      if (httpOptions.onSocketLookup) {
+        socket.on('lookup', () => {
+          httpOptions.onSocketLookup?.(requestParams)
+        })
+      }
+      if (httpOptions.onSocketConnect) {
+        socket.on('connect', () => {
+          httpOptions.onSocketConnect?.(requestParams)
+        })
+      }
+      if (httpOptions.onSocketSecureConnect) {
+        socket.on('secureConnect', () => {
+          httpOptions.onSocketSecureConnect?.(requestParams)
+        })
+      }
     })
 
     httpRequest.on('error', (e) => this.onError(e))
@@ -123,12 +134,6 @@ export class HTTP extends Gateway {
     }
 
     httpRequest.end()
-  }
-
-  assignSocketListener(socket: Socket, event: 'lookup' | 'connect' | 'secureConnect', listener: (() => void) | null | undefined) {
-    if (typeof listener === 'function') {
-      socket.on(event, () => listener())
-    }
   }
 
   onResponse(


### PR DESCRIPTION
Fixes #390 
This pull request contains:
- [The spec](https://github.com/tulios/mappersmith/pull/391/files#diff-f7285d0cc47d59dcea7a2d0488dbdee625f914ff697b5bd9b574b8e160758545R91-R98) to reproduce the memory leak condition and the fix
- Inverted logic for the [sockets related event listener assignments](https://github.com/tulios/mappersmith/pull/391/files#diff-97d4b84b631227c34c616f2edd0036181c063f4d022e56009ecba4b3e171f8c2R104-R106). The event listeners only register if the specific hook is defined in the HTTP gatewayConfig object.

The spec fails without the fix: when keep-alive is enabled, the tcp socket events register twice (once per API call):
> [test] 1) integration HTTP event callbacks keep alive
[test]   Message:
[test]     Expected 2 to be 1.
[test]   Stack:
[test]         at <Jasmine>
[test]         at Object.verifySockets (/Users/notanengineer/Documents/GitHub/mappersmith/spec/integration/node/support/keep-alive.js:13:46)
[test]         at /Users/notanengineer/Documents/GitHub/mappersmith/spec/integration/node/integration.spec.js:95:27
[test]         at processTicksAndRejections (node:internal/process/task_queues:96:5)
[test]   Message:
[test]     Expected 2 to be 1.
[test]   Stack:
[test]         at <Jasmine>
[test]         at Object.verifySockets (/Users/notanengineer/Documents/GitHub/mappersmith/spec/integration/node/support/keep-alive.js:14:47)
[test]         at /Users/notanengineer/Documents/GitHub/mappersmith/spec/integration/node/integration.spec.js:95:27
[test]         at processTicksAndRejections (node:internal/process/task_queues:96:5)
[test] 
[test] 20 specs, 1 failure
[test] Finished in 0.819 seconds