### PR TITLE
Fix: missing types for unusedMocks

### DIFF
--- a/.changeset/spotty-steaks-hide.md
+++ b/.changeset/spotty-steaks-hide.md
@@ -1,0 +1,5 @@
+---
+'mappersmith': patch
+---
+
+Fixed missing type declaration for `unusedMocks`

--- a/src/test/index.d.ts
+++ b/src/test/index.d.ts
@@ -32,6 +32,7 @@ export function lookupResponseAsync(req: any): Promise<any>
 export function clear(): void
 export function install(): void
 export function uninstall(): void
+export function unusedMocks(): number
 export function mockClient<
   ResourcesType,
   ResourceName extends keyof ResourcesType = keyof ResourcesType,


### PR DESCRIPTION
Fixes #393 
Added missing type declarations for exported unusedMocks test function