### PR TITLE
Prepare release 2.43.0

### DIFF
--- a/.changeset/dirty-years-sparkle.md
+++ b/.changeset/dirty-years-sparkle.md
@@ -1,9 +1,0 @@
----
-'mappersmith': minor
----
-
-Bundle with ESM exports.
-
-- The recommended way to use mappersmith in ESM projects is to do `import { forge } from 'mappersmith'` rather than the old `import forge from 'mappersmith'`. The reason is because test runners like jest and vitest might get confused when mixing named/default exports together with ESM, even though tsc and node has no problems with it.
-- A similar recommendation change goes for importing middleware: do `import { EncodeJsonMiddleware } from 'mappersmith/middleware'` (note the `mappersmith/middleware` folder) rather than deep import `import EncodeJsonMiddleware from 'mappersmith/middleware/encode-json'`. We still support the old import, but it will be deprecated in the future.
-- The same recommendation goes for importing gateway: do `import { FetchGateway } from 'mappersmith/gateway'` (note the `mappersmith/gateway` folder) rather than deep import `import FetchGateway from 'mappersmith/gateway/fetch'`. We still support the old import, but it will be deprecated in the future.

--- a/.changeset/friendly-bottles-unite.md
+++ b/.changeset/friendly-bottles-unite.md
@@ -1,5 +1,0 @@
----
-'mappersmith': minor
----
-
-Fixes memory leak when using http(s) agent with keep-alive

--- a/.changeset/spotty-steaks-hide.md
+++ b/.changeset/spotty-steaks-hide.md
@@ -1,5 +1,0 @@
----
-'mappersmith': patch
----
-
-Fixed missing type declaration for `unusedMocks`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.43.0
+
+### Minor Changes
+
+- 6e94f97: Bundle with ESM exports.
+
+  - The recommended way to use mappersmith in ESM projects is to do `import { forge } from 'mappersmith'` rather than the old `import forge from 'mappersmith'`. The reason is because test runners like jest and vitest might get confused when mixing named/default exports together with ESM, even though tsc and node has no problems with it.
+  - A similar recommendation change goes for importing middleware: do `import { EncodeJsonMiddleware } from 'mappersmith/middleware'` (note the `mappersmith/middleware` folder) rather than deep import `import EncodeJsonMiddleware from 'mappersmith/middleware/encode-json'`. We still support the old import, but it will be deprecated in the future.
+  - The same recommendation goes for importing gateway: do `import { FetchGateway } from 'mappersmith/gateway'` (note the `mappersmith/gateway` folder) rather than deep import `import FetchGateway from 'mappersmith/gateway/fetch'`. We still support the old import, but it will be deprecated in the future.
+
+- 9da82f6: Fixes memory leak when using http(s) agent with keep-alive
+
+### Patch Changes
+
+- e01114f: Fixed missing type declaration for `unusedMocks`
+
 ## 2.42.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ or
 yarn add mappersmith
 ```
 
-#### Browser
-
-Download the tag/latest version from the dist folder.
-
 #### Build from the source
 
 Install the dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mappersmith",
-  "version": "2.43.0-beta.1",
+  "version": "2.43.0",
   "description": "It is a lightweight rest client for node.js and the browser",
   "author": "Tulio Ornelas <ornelas.tulio@gmail.com>",
   "contributors": [

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.43.0-beta.1'
+export const version = '2.43.0'


### PR DESCRIPTION
## 2.43.0

### Minor Changes

- 6e94f97: Bundle with ESM exports.

  - The recommended way to use mappersmith in ESM projects is to do `import { forge } from 'mappersmith'` rather than the old `import forge from 'mappersmith'`. The reason is because test runners like jest and vitest might get confused when mixing named/default exports together with ESM, even though tsc and node has no problems with it.
  - A similar recommendation change goes for importing middleware: do `import { EncodeJsonMiddleware } from 'mappersmith/middleware'` (note the `mappersmith/middleware` folder) rather than deep import `import EncodeJsonMiddleware from 'mappersmith/middleware/encode-json'`. We still support the old import, but it will be deprecated in the future.
  - The same recommendation goes for importing gateway: do `import { FetchGateway } from 'mappersmith/gateway'` (note the `mappersmith/gateway` folder) rather than deep import `import FetchGateway from 'mappersmith/gateway/fetch'`. We still support the old import, but it will be deprecated in the future.

- 9da82f6: Fixes memory leak when using http(s) agent with keep-alive

### Patch Changes

- e01114f: Fixed missing type declaration for `unusedMocks`
