### PR TITLE
Smoke test release candidate

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -4,7 +4,12 @@ description: 'Setup Environment'
 inputs:
   node-version:
     description: 'Node.js version'
+    required: false
     default: '18'
+  path:
+    description: 'Path to the directory containing the package.json file'
+    required: false
+    default: '.'
 
 runs:
   using: composite
@@ -30,5 +35,7 @@ runs:
           ${{ runner.os }}-yarn-
 
     - name: Install dependencies
-      run: yarn install --immutable --immutable-cache
+      run: |
+        cd ${{ inputs.path }}
+        yarn install --immutable --immutable-cache
       shell: bash

--- a/.github/actions/setup-smoke-test/action.yml
+++ b/.github/actions/setup-smoke-test/action.yml
@@ -1,0 +1,55 @@
+name: 'Setup Environment'
+description: 'Setup Environment'
+
+inputs:
+  node-version:
+    description: Node version
+    required: false
+    default: '18'
+  bun-version:
+    description: Bun version
+    required: false
+    default: '1.0.18'
+
+runs:
+  using: composite
+  steps:
+    - name: Install node ${{ inputs.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install bun
+      uses: oven-sh/setup-bun@v1
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install deps in mappersmith/
+      run: |
+        cd mappersmith
+        yarn install --immutable --immutable-cache
+      shell: bash
+
+    - name: Checkout mappersmith-consumer/
+      uses: actions/checkout@v4
+      with:
+        repository: klippx/mappersmith-consumer
+        path: mappersmith-consumer
+
+    - name: Install deps in mappersmith-consumer/
+      run: |
+        cd mappersmith-consumer
+        yarn install --immutable --immutable-cache
+      shell: bash
+
+    - name: Build mappersmith release candidate
+      run: |
+        cd mappersmith
+        yarn publish:prepare
+      shell: bash
+
+    - name: Link mappersmith release candidate
+      run: |
+        cd mappersmith-consumer
+        yarn link ../mappersmith/dist
+      shell: bash

--- a/.github/workflows/smoke.js.yml
+++ b/.github/workflows/smoke.js.yml
@@ -1,0 +1,55 @@
+name: Smoke Test Release
+
+concurrency:
+  cancel-in-progress: true
+  group: 'smoke-test-${{ github.ref_name }}'
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  smoke-test-build:
+    name: Smoke Test Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: mappersmith
+      - uses: ./mappersmith/.github/actions/setup-smoke-test
+      - name: Smoke test tsc compile
+        run: |
+          cd mappersmith-consumer
+          yarn build:all
+        shell: bash
+
+  smoke-test-unit:
+    name: Smoke Test Unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: mappersmith
+      - uses: ./mappersmith/.github/actions/setup-smoke-test
+      - name: Smoke test unit tests
+        run: |
+          cd mappersmith-consumer
+          yarn test:all
+        shell: bash
+
+  smoke-test-integration:
+    name: Smoke Test Integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mappersmith/
+        uses: actions/checkout@v4
+        with:
+          path: mappersmith
+      - uses: ./mappersmith/.github/actions/setup-smoke-test
+      - name: Smoke test integration tests
+        run: |
+          cd mappersmith-consumer
+          yarn integration:all
+        shell: bash


### PR DESCRIPTION
### Problem

Fixes #408 

### Solution

This PR smoke tests a release to ensure the npm artefact is ready for release. The steps are roughly:
1. Clone repo, install deps
2. Prepare a mappersmith release
3. Clone https://github.com/klippx/mappersmith-consumer repo 
4. In `mappersmith-consumer`: Link to the release candidate
5. In `mappersmith-consumer`: Run all test scripts verifying that they run with release candidate

### Impact

- This ensures that consumer projects are not broken*
- If there is a missed case it is easy to add to that as a new workspace consumer project
- No impact on this project in terms of deps

*) to the extent that we know about it and that it is documented, of course