### PR TITLE
Export ClientBuilder from index.ts

### DIFF
--- a/.changeset/empty-mirrors-fail.md
+++ b/.changeset/empty-mirrors-fail.md
@@ -1,0 +1,5 @@
+---
+"mappersmith": patch
+---
+
+Exporting client-builder

--- a/package.json
+++ b/package.json
@@ -131,6 +131,10 @@
     "./middlewares/timeout": {
       "import": "./dist/esm/middlewares/timeout.mjs",
       "require": "./dist/middlewares/timeout.js"
+    },
+    "./client-builder": {
+      "import": "./dist/esm/client-builder.mjs",
+      "require": "./dist/client-builder.js"
     }
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export type {
   RequestGetter,
   ResponseGetter,
 } from './middleware/index'
-export type { AsyncFunction, AsyncFunctions, Client } from './client-builder'
+export type { AsyncFunction, AsyncFunctions, Client, ClientBuilder } from './client-builder'
 /**
  * @deprecated, use ManifestOptions instead
  */


### PR DESCRIPTION
Since version 2.43.0 the imports are broken for 'mappersmith/client-builder', everything else is exported from index.ts, except for `ClientBuilder` class