### PR TITLE
Add support for AbortSignal

### DIFF
--- a/.changeset/sharp-vans-approve.md
+++ b/.changeset/sharp-vans-approve.md
@@ -1,0 +1,5 @@
+---
+'mappersmith': minor
+---
+
+Add support for abort signals

--- a/.changeset/sharp-vans-approve.md
+++ b/.changeset/sharp-vans-approve.md
@@ -2,4 +2,24 @@
 'mappersmith': minor
 ---
 
-Add support for abort signals
+# Add support for abort signals
+
+The [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) interface represents a signal object that allows you to communicate with an asynchronous operation (such as a fetch request) and abort it if required via an AbortController object. All gateway APIs (Fetch, HTTP and XHR) support this interface via the `signal` parameter:
+
+```javascript
+const abortController = new AbortController()
+// Start a long running task...
+client.Bitcoin.mine({ signal: abortController.signal })
+// This takes too long, abort!
+abortController.abort()
+```
+
+# Minor type fixes
+
+The return value of some functions on `Request` have been updated to highlight that they might return undefined:
+
+- `Request#body()`
+- `Request#auth()`
+- `Request#timeout()`
+
+The reasoning behind this change is that if you didn't pass them (and no middleware set them) they might simply be undefined. So the types were simply wrong before. If you experience a "breaking change" due to this change, then it means you have a potential bug that you didn't properly handle before.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ __Mappersmith__ is a lightweight rest client for node.js and the browser. It cre
     - [Headers](#headers)
     - [Basic Auth](#basic-auth)
     - [Timeout](#timeout)
+    - [Abort Signal](#abort-signal)
     - [Alternative host](#alternative-host)
     - [Alternative path](#alternative-path)
     - [Binary data](#binary-data)
@@ -318,6 +319,34 @@ client.User.all({ maxWait: 500 })
 
 __NOTE__: A default timeout can be configured with the use of the [TimeoutMiddleware](#middleware-timeout), check the middleware section below for more information.
 __NOTE__: The `timeoutAttr` param can be set at manifest level.
+
+### <a name="abort-signal"></a> Abort Signal
+
+The AbortSignal interface represents a signal object that allows you to communicate with an asynchronous operation (such as a fetch request) and abort it if required via an AbortController object. All gateway APIs (Fetch, HTTP and XHR) support this interface via the `signal` parameter:
+
+```javascript
+const abortController = new AbortController()
+client.User.all({ signal: abortController.signal })
+// abort!
+abortController.abort()
+```
+
+If `signal` is not possible as a special parameter for your API you can configure it through the param `signalAttr`:
+
+```javascript
+// ...
+{
+  all: { path: '/users', signalAttr: 'abortSignal' }
+}
+// ...
+
+const abortController = new AbortController()
+client.User.all({ abortSignal: abortController.signal })
+// abort!
+abortController.abort()
+```
+
+__NOTE__: The `signalAttr` param can be set at manifest level.
 
 ### <a name="alternative-host"></a> Alternative host
 
@@ -1184,7 +1213,7 @@ describe('Feature', () => {
 
 ## <a name="gateways"></a> Gateways
 
-Mappersmith has a pluggable transport layer and it includes by default three gateways: xhr, http and fetch. Mappersmith will pick the correct gateway based on the environment you are running (nodejs or the browser).
+Mappersmith has a pluggable transport layer and it includes by default three gateways: xhr, http and fetch. Mappersmith will pick the correct gateway based on the environment you are running (nodejs, service worker or the browser).
 
 You can write your own gateway, take a look at [XHR](https://github.com/tulios/mappersmith/blob/master/src/gateway/xhr.js) for an example. To configure, import the `configs` object and assign the gateway option, like:
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ __NOTE__: The `timeoutAttr` param can be set at manifest level.
 
 ### <a name="abort-signal"></a> Abort Signal
 
-The AbortSignal interface represents a signal object that allows you to communicate with an asynchronous operation (such as a fetch request) and abort it if required via an AbortController object. All gateway APIs (Fetch, HTTP and XHR) support this interface via the `signal` parameter:
+The [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) interface represents a signal object that allows you to communicate with an asynchronous operation (such as a fetch request) and abort it if required via an AbortController object. All gateway APIs (Fetch, HTTP and XHR) support this interface via the `signal` parameter:
 
 ```javascript
 const abortController = new AbortController()

--- a/spec/integration/node/integration.spec.js
+++ b/spec/integration/node/integration.spec.js
@@ -4,8 +4,10 @@ import 'core-js/stable'
 import 'regenerator-runtime/runtime'
 import md5 from 'js-md5'
 import integrationTestsForGateway from 'spec/integration/shared-examples'
+import fetch from 'node-fetch'
 
 import HTTP from 'src/gateway/http'
+import Fetch from 'src/gateway/fetch'
 import forge, { configs } from 'src/index'
 import createManifest from 'spec/integration/support/manifest'
 import { errorMessage, INVALID_ADDRESS } from 'spec/integration/support'
@@ -17,6 +19,10 @@ describe('integration', () => {
     const gateway = HTTP
     const params = { host: 'http://localhost:9090' }
     const keepAliveHelper = keepAlive(params.host, gateway)
+
+    beforeAll(() => {
+      configs.gateway = HTTP
+    })
 
     describe('event callbacks', () => {
       let gatewayConfigs = {}
@@ -120,7 +126,6 @@ describe('integration', () => {
 
     describe('with raw binary', () => {
       it('GET /api/binary.pdf', (done) => {
-        console.log('starting test 1')
         const Client = forge({
           host: params.host,
           resources: {
@@ -133,7 +138,6 @@ describe('integration', () => {
           .then((response) => {
             expect(response.status()).toEqual(200)
             expect(md5(response.data())).toEqual('7e8dfc5e83261f49206a7cd860ccae0a')
-            console.log('finishing test 1')
             done()
           })
           .catch((response) => {
@@ -160,6 +164,65 @@ describe('integration', () => {
           .catch((response) => {
             expect(response.status()).toEqual(400)
             expect(response.error()).toMatch(/ENOTFOUND/i)
+            done()
+          })
+      })
+    })
+
+    describe('aborting a request', () => {
+      it('aborts the request', (done) => {
+        const Client = forge({
+          host: params.host,
+          resources: {
+            Timeout: {
+              get: { path: '/api/timeout.json' },
+            },
+          },
+        })
+        const abortController = new AbortController()
+        const request = Client.Timeout.get({ waitTime: 666, signal: abortController.signal })
+        abortController.abort()
+        request
+          .then((response) => {
+            done.fail(`Expected this request to fail: ${errorMessage(response)}`)
+          })
+          .catch((response) => {
+            expect(response.status()).toEqual(400)
+            expect(response.error()).toMatch(/The operation was aborted/i)
+            done()
+          })
+      })
+    })
+  })
+
+  describe('Fetch', () => {
+    const params = { host: 'http://localhost:9090' }
+
+    beforeAll(() => {
+      configs.gateway = Fetch
+    })
+
+    describe('aborting a request', () => {
+      it('aborts the request', (done) => {
+        const Client = forge({
+          host: params.host,
+          fetch,
+          resources: {
+            Timeout: {
+              get: { path: '/api/timeout.json' },
+            },
+          },
+        })
+        const abortController = new AbortController()
+        const request = Client.Timeout.get({ waitTime: 666, signal: abortController.signal })
+        abortController.abort()
+        request
+          .then((response) => {
+            done.fail(`Expected this request to fail: ${errorMessage(response)}`)
+          })
+          .catch((response) => {
+            expect(response.status()).toEqual(400)
+            expect(response.error()).toMatch(/This operation was aborted/i)
             done()
           })
       })

--- a/src/gateway/fetch.ts
+++ b/src/gateway/fetch.ts
@@ -37,7 +37,7 @@ export class Fetch extends Gateway {
     this.performRequest('delete')
   }
 
-  performRequest(method: Method) {
+  performRequest(requestMethod: Method) {
     const fetch = configs.fetch
 
     if (!fetch) {
@@ -47,7 +47,7 @@ export class Fetch extends Gateway {
     }
 
     const customHeaders: Record<string, string> = {}
-    const body = this.prepareBody(method, customHeaders) as BodyInit
+    const body = this.prepareBody(requestMethod, customHeaders) as BodyInit
     const auth = this.request.auth()
 
     if (auth) {
@@ -57,8 +57,9 @@ export class Fetch extends Gateway {
     }
 
     const headers = assign(customHeaders, this.request.headers())
-    const requestMethod = this.shouldEmulateHTTP() ? 'post' : method
-    const init: RequestInit = assign({ method: requestMethod, headers, body }, this.options().Fetch)
+    const method = this.shouldEmulateHTTP() ? 'post' : requestMethod
+    const signal = this.request.signal()
+    const init: RequestInit = assign({ method, headers, body, signal }, this.options().Fetch)
     const timeout = this.request.timeout()
 
     let timer: ReturnType<typeof setTimeout> | null = null

--- a/src/gateway/xhr.ts
+++ b/src/gateway/xhr.ts
@@ -22,6 +22,7 @@ export class XHR extends Gateway {
     this.setHeaders(xmlHttpRequest, {})
     this.configureTimeout(xmlHttpRequest)
     this.configureBinary(xmlHttpRequest)
+    this.configureAbort(xmlHttpRequest)
     xmlHttpRequest.send()
   }
 
@@ -31,6 +32,7 @@ export class XHR extends Gateway {
     this.setHeaders(xmlHttpRequest, {})
     this.configureTimeout(xmlHttpRequest)
     this.configureBinary(xmlHttpRequest)
+    this.configureAbort(xmlHttpRequest)
     xmlHttpRequest.send()
   }
 
@@ -77,6 +79,21 @@ export class XHR extends Gateway {
         const error = createTimeoutError(`Timeout (${timeout}ms)`)
         this.dispatchClientError(error.message, error)
       }, timeout + 1)
+    }
+  }
+
+  configureAbort(xmlHttpRequest: XMLHttpRequest) {
+    const signal = this.request.signal()
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        xmlHttpRequest.abort()
+      })
+      xmlHttpRequest.addEventListener('abort', () => {
+        this.dispatchClientError(
+          'The operation was aborted',
+          new Error('The operation was aborted')
+        )
+      })
     }
   }
 
@@ -128,6 +145,7 @@ export class XHR extends Gateway {
     this.setHeaders(xmlHttpRequest, customHeaders)
     this.configureTimeout(xmlHttpRequest)
     this.configureBinary(xmlHttpRequest)
+    this.configureAbort(xmlHttpRequest)
 
     xmlHttpRequest.send(body)
   }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -22,18 +22,19 @@ export type ResourceTypeConstraint = {
 }
 
 export interface ManifestOptions<Resources extends ResourceTypeConstraint> {
-  host: string
   allowResourceHostOverride?: boolean
-  parameterEncoder?: ParameterEncoderFn
-  bodyAttr?: string
-  headersAttr?: string
   authAttr?: string
-  timeoutAttr?: string
-  hostAttr?: string
+  bodyAttr?: string
   clientId?: string
   gatewayConfigs?: Partial<GatewayConfiguration>
-  resources?: Resources
+  headersAttr?: string
+  host: string
+  hostAttr?: string
   middleware?: Middleware[]
+  parameterEncoder?: ParameterEncoderFn
+  resources?: Resources
+  signalAttr?: string
+  timeoutAttr?: string
   /**
    * @deprecated - use `middleware` instead
    */
@@ -56,36 +57,38 @@ type CreateMiddlewareParams = Partial<Omit<MiddlewareParams, 'resourceName' | 'r
  * @param {Object} globalConfigs
  */
 export class Manifest<Resources extends ResourceTypeConstraint> {
-  public host: string
   public allowResourceHostOverride: boolean
-  public parameterEncoder: ParameterEncoderFn
-  public bodyAttr?: string
-  public headersAttr?: string
   public authAttr?: string
-  public timeoutAttr?: string
-  public hostAttr?: string
+  public bodyAttr?: string
   public clientId: string | null
-  public gatewayConfigs: GatewayConfiguration
-  public resources: Resources
   public context: Context
+  public gatewayConfigs: GatewayConfiguration
+  public headersAttr?: string
+  public host: string
+  public hostAttr?: string
   public middleware: Middleware[]
+  public parameterEncoder: ParameterEncoderFn
+  public resources: Resources
+  public signalAttr?: string
+  public timeoutAttr?: string
 
   constructor(
     options: ManifestOptions<Resources>,
     { gatewayConfigs, middleware = [], context = {} }: GlobalConfigs
   ) {
-    this.host = options.host
     this.allowResourceHostOverride = options.allowResourceHostOverride || false
-    this.parameterEncoder = options.parameterEncoder || encodeURIComponent
-    this.bodyAttr = options.bodyAttr
-    this.headersAttr = options.headersAttr
     this.authAttr = options.authAttr
-    this.timeoutAttr = options.timeoutAttr
-    this.hostAttr = options.hostAttr
+    this.bodyAttr = options.bodyAttr
     this.clientId = options.clientId || null
-    this.gatewayConfigs = assign({}, gatewayConfigs, options.gatewayConfigs)
-    this.resources = options.resources || ({} as Resources)
     this.context = context
+    this.gatewayConfigs = assign({}, gatewayConfigs, options.gatewayConfigs)
+    this.headersAttr = options.headersAttr
+    this.host = options.host
+    this.hostAttr = options.hostAttr
+    this.parameterEncoder = options.parameterEncoder || encodeURIComponent
+    this.resources = options.resources || ({} as Resources)
+    this.signalAttr = options.signalAttr
+    this.timeoutAttr = options.timeoutAttr
 
     // TODO: deprecate obj.middlewares in favor of obj.middleware
     const clientMiddleware = options.middleware || options.middlewares || []
@@ -130,6 +133,7 @@ export class Manifest<Resources extends ResourceTypeConstraint> {
           authAttr: this.authAttr,
           timeoutAttr: this.timeoutAttr,
           hostAttr: this.hostAttr,
+          signalAttr: this.signalAttr,
         },
         definition
       )

--- a/src/method-descriptor.ts
+++ b/src/method-descriptor.ts
@@ -3,7 +3,6 @@ import type { Middleware } from './middleware/index'
 
 export interface MethodDescriptorParams {
   allowResourceHostOverride?: boolean
-  parameterEncoder?: ParameterEncoderFn
   authAttr?: string
   binary?: boolean
   bodyAttr?: string
@@ -14,10 +13,12 @@ export interface MethodDescriptorParams {
   method?: string
   middleware?: Array<Middleware>
   middlewares?: Array<Middleware>
+  parameterEncoder?: ParameterEncoderFn
   params?: Params
   path: string | ((args: RequestParams) => string)
   pathAttr?: string
   queryParamAlias?: Record<string, string>
+  signalAttr?: string
   timeoutAttr?: string
 }
 
@@ -44,7 +45,6 @@ export interface MethodDescriptorParams {
  */
 export class MethodDescriptor {
   public readonly allowResourceHostOverride: boolean
-  public readonly parameterEncoder: ParameterEncoderFn
   public readonly authAttr: string
   public readonly binary: boolean
   public readonly bodyAttr: string
@@ -54,19 +54,21 @@ export class MethodDescriptor {
   public readonly hostAttr: string
   public readonly method: string
   public readonly middleware: Middleware[]
+  public readonly parameterEncoder: ParameterEncoderFn
   public readonly params?: RequestParams
   public readonly path: string | ((args: RequestParams) => string)
   public readonly pathAttr: string
   public readonly queryParamAlias: Record<string, string>
+  public readonly signalAttr: string
   public readonly timeoutAttr: string
 
   constructor(params: MethodDescriptorParams) {
     this.allowResourceHostOverride = params.allowResourceHostOverride || false
-    this.parameterEncoder = params.parameterEncoder || encodeURIComponent
     this.binary = params.binary || false
     this.headers = params.headers
     this.host = params.host
     this.method = params.method || 'get'
+    this.parameterEncoder = params.parameterEncoder || encodeURIComponent
     this.params = params.params
     this.path = params.path
     this.queryParamAlias = params.queryParamAlias || {}
@@ -76,6 +78,7 @@ export class MethodDescriptor {
     this.headersAttr = params.headersAttr || 'headers'
     this.hostAttr = params.hostAttr || 'host'
     this.pathAttr = params.pathAttr || 'path'
+    this.signalAttr = params.signalAttr || 'signal'
     this.timeoutAttr = params.timeoutAttr || 'timeout'
 
     const resourceMiddleware = params.middleware || params.middlewares || []

--- a/src/method-descriptor.ts
+++ b/src/method-descriptor.ts
@@ -41,6 +41,7 @@ export interface MethodDescriptorParams {
  *   @param {String|Function} params.path
  *   @param {String} params.pathAttr. Default: 'path'
  *   @param {Object} params.queryParamAlias
+ *   @param {Number} params.signalAttr - signal attribute name. Default: 'signal'
  *   @param {Number} params.timeoutAttr - timeout attribute name. Default: 'timeout'
  */
 export class MethodDescriptor {

--- a/src/request.spec.ts
+++ b/src/request.spec.ts
@@ -746,6 +746,11 @@ describe('Request', () => {
       const request = new Request(methodDescriptor, { differentParam: 'abc123' })
       expect(request.body()).toEqual('abc123')
     })
+
+    it('can return undefined', () => {
+      const request = new Request(methodDescriptor, { ...requestParams, body: undefined })
+      expect(request.body()).toBeUndefined()
+    })
   })
 
   describe('#auth', () => {
@@ -763,6 +768,11 @@ describe('Request', () => {
       const request = new Request(methodDescriptor, { differentAuthParam: authData })
       expect(request.auth()).toEqual(authData)
     })
+
+    it('can return undefined', () => {
+      const request = new Request(methodDescriptor, { ...requestParams, auth: undefined })
+      expect(request.auth()).toBeUndefined()
+    })
   })
 
   describe('#timeout', () => {
@@ -778,6 +788,11 @@ describe('Request', () => {
       })
       const request = new Request(methodDescriptor, { differentTimeoutParam: 1000 })
       expect(request.timeout()).toEqual(1000)
+    })
+
+    it('can return undefined', () => {
+      const request = new Request(methodDescriptor, { ...requestParams, timeout: undefined })
+      expect(request.timeout()).toBeUndefined()
     })
   })
 
@@ -799,6 +814,11 @@ describe('Request', () => {
         differentSignalParam: abortController.signal,
       })
       expect(request.signal()).toEqual(abortController.signal)
+    })
+
+    it('can return undefined', () => {
+      const request = new Request(methodDescriptor, requestParams)
+      expect(request.signal()).toBeUndefined()
     })
   })
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -49,6 +49,7 @@ export class Request {
       key !== this.methodDescriptor.authAttr &&
       key !== this.methodDescriptor.timeoutAttr &&
       key !== this.methodDescriptor.hostAttr &&
+      key !== this.methodDescriptor.signalAttr &&
       key !== this.methodDescriptor.pathAttr
     )
   }
@@ -238,15 +239,19 @@ export class Request {
   }
 
   public body() {
-    return this.requestParams[this.methodDescriptor.bodyAttr] as Body
+    return this.requestParams[this.methodDescriptor.bodyAttr] as Body | undefined
   }
 
   public auth() {
-    return this.requestParams[this.methodDescriptor.authAttr] as Auth
+    return this.requestParams[this.methodDescriptor.authAttr] as Auth | undefined
   }
 
   public timeout() {
-    return this.requestParams[this.methodDescriptor.timeoutAttr] as number
+    return this.requestParams[this.methodDescriptor.timeoutAttr] as number | undefined
+  }
+
+  public signal() {
+    return this.requestParams[this.methodDescriptor.signalAttr] as AbortSignal | undefined
   }
 
   /**
@@ -267,6 +272,7 @@ export class Request {
     const hostKey = this.methodDescriptor.hostAttr
     const timeoutKey = this.methodDescriptor.timeoutAttr
     const pathKey = this.methodDescriptor.pathAttr
+    const signalKey = this.methodDescriptor.signalAttr
 
     // Note: The result of merging an instance of RequestParams with instance of Params
     // is simply a RequestParams with even more [param: string]'s on it.
@@ -281,6 +287,7 @@ export class Request {
     extras.host && (requestParams[hostKey] = extras.host)
     extras.timeout && (requestParams[timeoutKey] = extras.timeout)
     extras.path && (requestParams[pathKey] = extras.path)
+    extras.signal && (requestParams[signalKey] = extras.signal)
 
     const nextContext = { ...this.requestContext, ...requestContext }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface RequestParams {
   readonly path?: string
   readonly params?: Params
   readonly timeout?: number
+  readonly signal?: AbortSignal
   [param: string]: object | Primitive | undefined | null | NestedParam | NestedParamArray
 }
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal

It is standard practice for all APIs capable of using the AbortController API to take the signal property of an AbortController class instance as an argument. In Mappersmith case, we are the glue between the user and Fetch / HTTP and these APIs support AbortController API. Let's get out of the way and let people use it if they need.