### PR TITLE
Use non-wildcard imports in mappersmith gateway

### DIFF
--- a/src/gateway/http.ts
+++ b/src/gateway/http.ts
@@ -1,6 +1,6 @@
-import * as url from 'url'
-import * as http from 'http'
-import * as https from 'https'
+import url from 'url'
+import http from 'http'
+import https from 'https'
 
 import { assign } from '../utils/index'
 import { Gateway } from './gateway'


### PR DESCRIPTION
- Switch to using default imports for libraries imported in gateway
- Default imports (import http) create a direct reference to the module exports
- Named imports and namespace imports (import * as) create a new reference that won't reflect patches

We have a use case where we patch methods exposed by `node:http` and `node:https` globally in a node.js application. This affects applications compiled using ESM. CJS application are unaffected. Tested this change and this doesn't affect any existing applications using mappersmith.