### PR TITLE
Prepare release 2.45.0

### DIFF
--- a/.changeset/five-squids-sip.md
+++ b/.changeset/five-squids-sip.md
@@ -1,5 +1,0 @@
----
-'mappersmith': minor
----
-
-Switch to using default imports for libraries imported in gateway

--- a/.changeset/five-squids-sip.md
+++ b/.changeset/five-squids-sip.md
@@ -1,0 +1,5 @@
+---
+'mappersmith': minor
+---
+
+Switch to using default imports for libraries imported in gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.45.0
+
+### Minor Changes
+
+- 624c15d: Switch to using default imports for libraries imported in gateway
+
 ## 2.44.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mappersmith",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "It is a lightweight rest client for node.js and the browser",
   "author": "Tulio Ornelas <ornelas.tulio@gmail.com>",
   "contributors": [

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.44.0'
+export const version = '2.45.0'


### PR DESCRIPTION
## 2.45.0

### Minor Changes

- 624c15d: Switch to using default imports for libraries imported in gateway
