### PR TITLE
Abort request for Fetch after Timeout reached

### DIFF
--- a/.changeset/silent-paws-itch.md
+++ b/.changeset/silent-paws-itch.md
@@ -1,0 +1,5 @@
+---
+'mappersmith': minor
+---
+
+Fetch gateway will now send abort controller signal when timeout has been reached


### PR DESCRIPTION
When using node's native Fetch or even `node-fetch` fetch, we need to relay the timeout via `signal` to the library to allow it to actually cancel the request on the wire instead of leaving it hanging