### PR TITLE
Fetch gateway does not normalize HTTP method casing, leading to request issues with undici 

### DIFF
--- a/.changeset/dull-chefs-report.md
+++ b/.changeset/dull-chefs-report.md
@@ -1,0 +1,5 @@
+---
+'mappersmith': patch
+---
+
+Update the performRequest method in the Fetch gateway to normalize the HTTP method to uppercase to mitigate issue with PATCH calls and undici

--- a/src/gateway/fetch.ts
+++ b/src/gateway/fetch.ts
@@ -56,7 +56,7 @@ export class Fetch extends Gateway {
     }
 
     const customHeaders: Record<string, string> = {}
-    const body = this.prepareBody(requestMethod, customHeaders)
+    const body = this.prepareBody(requestMethod.toUpperCase(), customHeaders)
     const auth = this.request.auth()
 
     if (auth) {
@@ -66,7 +66,7 @@ export class Fetch extends Gateway {
     }
 
     const headers = assign(customHeaders, this.request.headers())
-    const method = this.shouldEmulateHTTP() ? 'post' : requestMethod
+    const method = this.shouldEmulateHTTP() ? 'POST' : requestMethod.toUpperCase()
     const userSignal = this.request.signal()
 
     // Since 1) node fetch requires timeout to be handled via abort controller and 2) we support an external user signal, we need to merge them:


### PR DESCRIPTION
It appears that the Fetch gateway in Mappersmith does not normalize the HTTP method to uppercase, which can cause issues when using HTTP clients like undici that are case-sensitive about method names.

This is a small fix for an issue related to PATCH requests not working properly producing a 400 Bad Request error.

