### PR TITLE
Prepare release 2.46.0

### DIFF
--- a/.changeset/silent-paws-itch.md
+++ b/.changeset/silent-paws-itch.md
@@ -1,5 +1,0 @@
----
-'mappersmith': minor
----
-
-Fetch gateway will now send abort controller signal when timeout has been reached

--- a/.changeset/tired-wolves-refuse.md
+++ b/.changeset/tired-wolves-refuse.md
@@ -1,8 +1,0 @@
----
-'mappersmith': minor
----
-
-Automatically retry failed network errors
-
-- feat: add automatic retry for failed network request to Retry Middleware
-- feat: Allow `enableRetry` as a new config option to Retry Middleware

--- a/.changeset/two-waves-press.md
+++ b/.changeset/two-waves-press.md
@@ -1,5 +1,0 @@
----
-'mappersmith': patch
----
-
-Import built-in Node.js modules using `import * as` syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.46.0
+
+### Minor Changes
+
+- e5b96ac: Fetch gateway will now send abort controller signal when timeout has been reached
+- 9353c80: Automatically retry failed network errors
+  - feat: add automatic retry for failed network request to Retry Middleware
+  - feat: Allow `enableRetry` as a new config option to Retry Middleware
+
+### Patch Changes
+
+- f8b9add: Import built-in Node.js modules using `import * as` syntax
+
 ## 2.45.0
 
 ### Minor Changes
@@ -25,7 +38,6 @@
   # Minor type fixes
 
   The return value of some functions on `Request` have been updated to highlight that they might return undefined:
-
   - `Request#body()`
   - `Request#auth()`
   - `Request#timeout()`
@@ -61,7 +73,6 @@
 ### Minor Changes
 
 - 6e94f97: Bundle with ESM exports.
-
   - The recommended way to use mappersmith in ESM projects is to do `import { forge } from 'mappersmith'` rather than the old `import forge from 'mappersmith'`. The reason is because test runners like jest and vitest might get confused when mixing named/default exports together with ESM, even though tsc and node has no problems with it.
   - A similar recommendation change goes for importing middleware: do `import { EncodeJsonMiddleware } from 'mappersmith/middleware'` (note the `mappersmith/middleware` folder) rather than deep import `import EncodeJsonMiddleware from 'mappersmith/middleware/encode-json'`. We still support the old import, but it will be deprecated in the future.
   - The same recommendation goes for importing gateway: do `import { FetchGateway } from 'mappersmith/gateway'` (note the `mappersmith/gateway` folder) rather than deep import `import FetchGateway from 'mappersmith/gateway/fetch'`. We still support the old import, but it will be deprecated in the future.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mappersmith",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "description": "It is a lightweight rest client for node.js and the browser",
   "author": "Tulio Ornelas <ornelas.tulio@gmail.com>",
   "contributors": [

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.45.0'
+export const version = '2.46.0'


### PR DESCRIPTION
## 2.46.0

### Minor Changes

- e5b96ac: Fetch gateway will now send abort controller signal when timeout has been reached
- 9353c80: Automatically retry failed network errors
  - feat: add automatic retry for failed network request to Retry Middleware
  - feat: Allow `enableRetry` as a new config option to Retry Middleware

### Patch Changes

- f8b9add: Import built-in Node.js modules using `import * as` syntax
